### PR TITLE
Refactoring isClique to GraphUtils version

### DIFF
--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/graph/GraphUtils.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/graph/GraphUtils.java
@@ -1111,7 +1111,7 @@ public final class GraphUtils {
      * @return true if <code>set</code> is a clique in <code>graph</code>. </p>
      * R. Silva, June 2004
      */
-    public static boolean isClique(Set<Node> set, Graph graph) {
+    public static boolean isClique(Collection<Node> set, Graph graph) {
         List<Node> setv = new LinkedList<>(set);
         for (int i = 0; i < setv.size() - 1; i++) {
             for (int j = i + 1; j < setv.size(); j++) {

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/BffGes.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/BffGes.java
@@ -497,7 +497,7 @@ public final class BffGes implements Bff {
         List<Node> naYXT = new LinkedList<>(subset);
         naYXT.addAll(findNaYX(x, y, graph));
 
-        return isClique(naYXT, graph) && isSemiDirectedBlocked(x, y, naYXT, graph, new HashSet<Node>());
+        return GraphUtils.isClique(naYXT, graph) && isSemiDirectedBlocked(x, y, naYXT, graph, new HashSet<Node>());
 
     }
 
@@ -508,7 +508,7 @@ public final class BffGes implements Bff {
                                        Graph graph) {
         List<Node> naYXH = findNaYX(x, y, graph);
         naYXH.removeAll(h);
-        return isClique(naYXH, graph);
+        return GraphUtils.isClique(naYXH, graph);
     }
 
     /**
@@ -643,21 +643,6 @@ public final class BffGes implements Bff {
 //
 //        return score1 - score2;
 //    }
-
-    /**
-     * @return true iif the given set forms a clique in the given graph.
-     */
-    private static boolean isClique(List<Node> set, Graph graph) {
-        List<Node> setv = new LinkedList<>(set);
-        for (int i = 0; i < setv.size() - 1; i++) {
-            for (int j = i + 1; j < setv.size(); j++) {
-                if (!graph.isAdjacentTo(setv.get(i), setv.get(j))) {
-                    return false;
-                }
-            }
-        }
-        return true;
-    }
 
     /**
      * Verifies if every semidirected path from y to x contains a node in naYXT.

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/Fges.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/Fges.java
@@ -1117,7 +1117,7 @@ public final class Fges implements GraphSearch, GraphScorer {
         }
 
         Set<Node> naYX = getNaYX(a, b);
-        if (!isClique(naYX)) return;
+        if (!GraphUtils.isClique(naYX, this.graph)) return;
 
         List<Node> TNeighbors = getTNeighbors(a, b);
 
@@ -1149,7 +1149,7 @@ public final class Fges implements GraphSearch, GraphScorer {
                     break FOR;
                 }
 
-                if (!isClique(union)) continue;
+                if (!GraphUtils.isClique(union, this.graph)) continue;
                 newCliques.add(union);
 
                 double bump = insertEval(a, b, T, naYX, hashIndices);
@@ -1552,7 +1552,7 @@ public final class Fges implements GraphSearch, GraphScorer {
 
         Set<Node> union = new HashSet<>(T);
         union.addAll(naYX);
-        boolean clique = isClique(union);
+        boolean clique = GraphUtils.isClique(union, this.graph);
         boolean noCycle = !existsUnblockedSemiDirectedPath(y, x, union, cycleBound);
         return clique && noCycle && !violatesKnowledge;
     }
@@ -1574,7 +1574,7 @@ public final class Fges implements GraphSearch, GraphScorer {
 
         Set<Node> diff = new HashSet<>(naYX);
         diff.removeAll(H);
-        return isClique(diff) && !violatesKnowledge;
+        return GraphUtils.isClique(diff, this.graph) && !violatesKnowledge;
     }
 
     // Adds edges required by knowledge.
@@ -1669,21 +1669,6 @@ public final class Fges implements GraphSearch, GraphScorer {
         return nayx;
     }
 
-    Set<Edge> cliqueEdges = new HashSet<>();
-
-    // Returns true iif the given set forms a clique in the given graph.
-    private boolean isClique(Set<Node> nodes) {
-        List<Node> _nodes = new ArrayList<>(nodes);
-        for (int i = 0; i < _nodes.size() - 1; i++) {
-            for (int j = i + 1; j < _nodes.size(); j++) {
-                if (!graph.isAdjacentTo(_nodes.get(i), _nodes.get(j))) {
-                    return false;
-                }
-            }
-        }
-
-        return true;
-    }
 
     // Returns true if a path consisting of undirected and directed edges toward 'to' exists of
     // length at most 'bound'. Cycle checker in other words.

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/FgesMb.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/FgesMb.java
@@ -856,7 +856,7 @@ public final class FgesMb {
         }
 
         Set<Node> naYX = getNaYX(a, b);
-        if (!isClique(naYX)) return;
+        if (!GraphUtils.isClique(naYX, this.graph)) return;
 
         List<Node> TNeighbors = getTNeighbors(a, b);
 
@@ -890,7 +890,7 @@ public final class FgesMb {
                     break FOR;
                 }
 
-                if (!isClique(union)) continue;
+                if (!GraphUtils.isClique(union, this.graph)) continue;
                 newCliques.add(union);
 
                 double bump = insertEval(a, b, T, naYX, hashIndices);
@@ -1240,7 +1240,7 @@ public final class FgesMb {
 
         Set<Node> union = new HashSet<>(T);
         union.addAll(naYX);
-        boolean clique = isClique(union);
+        boolean clique = GraphUtils.isClique(union, this.graph);
         boolean noCycle = !existsUnblockedSemiDirectedPath(y, x, union, cycleBound);
         return clique && noCycle && !violatesKnowledge;
     }
@@ -1262,7 +1262,7 @@ public final class FgesMb {
 
         Set<Node> diff = new HashSet<>(naYX);
         diff.removeAll(H);
-        return isClique(diff) && !violatesKnowledge;
+        return GraphUtils.isClique(diff, this.graph) && !violatesKnowledge;
     }
 
     // Adds edges required by knowledge.
@@ -1355,20 +1355,6 @@ public final class FgesMb {
         }
 
         return nayx;
-    }
-
-    // Returns true iif the given set forms a clique in the given graph.
-    private boolean isClique(Set<Node> nodes) {
-        List<Node> _nodes = new ArrayList<>(nodes);
-        for (int i = 0; i < _nodes.size() - 1; i++) {
-            for (int j = i + 1; j < _nodes.size(); j++) {
-                if (!graph.isAdjacentTo(_nodes.get(i), _nodes.get(j))) {
-                    return false;
-                }
-            }
-        }
-
-        return true;
     }
 
     // Returns true if a path consisting of undirected and directed edges toward 'to' exists of

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/FgesMb2.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/FgesMb2.java
@@ -1320,7 +1320,7 @@ public final class FgesMb2 {
         }
 
         Set<Node> naYX = getNaYX(a, b);
-        if (!isClique(naYX)) return;
+        if (!GraphUtils.isClique(naYX, this.graph)) return;
 
         List<Node> TNeighbors = getTNeighbors(a, b);
         int _maxIndegree = maxIndegree == -1 ? 1000 : maxIndegree;
@@ -1355,7 +1355,7 @@ public final class FgesMb2 {
                     break FOR;
                 }
 
-                if (!isClique(union)) continue;
+                if (!GraphUtils.isClique(union, this.graph)) continue;
                 newCliques.add(union);
 
                 double bump = insertEval(a, b, T, naYX, hashIndices);
@@ -1757,7 +1757,7 @@ public final class FgesMb2 {
 
         Set<Node> union = new HashSet<>(T);
         union.addAll(naYX);
-        boolean clique = isClique(union);
+        boolean clique = GraphUtils.isClique(union, this.graph);
         boolean noCycle = !existsUnblockedSemiDirectedPath(y, x, union, cycleBound);
         return clique && noCycle && !violatesKnowledge;
     }
@@ -1779,7 +1779,7 @@ public final class FgesMb2 {
 
         Set<Node> diff = new HashSet<>(naYX);
         diff.removeAll(H);
-        return isClique(diff) && !violatesKnowledge;
+        return GraphUtils.isClique(diff, this.graph) && !violatesKnowledge;
     }
 
     // Adds edges required by knowledge.
@@ -1874,21 +1874,6 @@ public final class FgesMb2 {
         return nayx;
     }
 
-    Set<Edge> cliqueEdges = new HashSet<>();
-
-    // Returns true iif the given set forms a clique in the given graph.
-    private boolean isClique(Set<Node> nodes) {
-        List<Node> _nodes = new ArrayList<>(nodes);
-        for (int i = 0; i < _nodes.size() - 1; i++) {
-            for (int j = i + 1; j < _nodes.size(); j++) {
-                if (!graph.isAdjacentTo(_nodes.get(i), _nodes.get(j))) {
-                    return false;
-                }
-            }
-        }
-
-        return true;
-    }
 
     // Returns true if a path consisting of undirected and directed edges toward 'to' exists of
     // length at most 'bound'. Cycle checker in other words.

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/FgesOld.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/FgesOld.java
@@ -986,7 +986,7 @@ public final class FgesOld implements GraphSearch, GraphScorer {
         }
 
         Set<Node> naYX = getNaYX(a, b);
-        if (!isClique(naYX)) return;
+        if (!GraphUtils.isClique(naYX, this.graph)) return;
 
         List<Node> TNeighbors = getTNeighbors(a, b);
 
@@ -1020,7 +1020,7 @@ public final class FgesOld implements GraphSearch, GraphScorer {
                     break FOR;
                 }
 
-                if (!isClique(union)) continue;
+                if (!GraphUtils.isClique(union, this.graph)) continue;
                 newCliques.add(union);
 
                 double bump = insertEval(a, b, T, naYX, hashIndices);
@@ -1434,7 +1434,7 @@ public final class FgesOld implements GraphSearch, GraphScorer {
 
         Set<Node> union = new HashSet<>(T);
         union.addAll(naYX);
-        boolean clique = isClique(union);
+        boolean clique = GraphUtils.isClique(union, this.graph);
         boolean noCycle = !existsUnblockedSemiDirectedPath(y, x, union, cycleBound);
         return clique && noCycle && !violatesKnowledge;
     }
@@ -1456,7 +1456,7 @@ public final class FgesOld implements GraphSearch, GraphScorer {
 
         Set<Node> diff = new HashSet<>(naYX);
         diff.removeAll(H);
-        return isClique(diff) && !violatesKnowledge;
+        return GraphUtils.isClique(diff, this.graph) && !violatesKnowledge;
     }
 
     // Adds edges required by knowledge.
@@ -1554,20 +1554,6 @@ public final class FgesOld implements GraphSearch, GraphScorer {
         }
 
         return nayx;
-    }
-
-    // Returns true iif the given set forms a clique in the given graph.
-    private boolean isClique(Set<Node> nodes) {
-        List<Node> _nodes = new ArrayList<>(nodes);
-        for (int i = 0; i < _nodes.size() - 1; i++) {
-            for (int j = i + 1; j < _nodes.size(); j++) {
-                if (!graph.isAdjacentTo(_nodes.get(i), _nodes.get(j))) {
-                    return false;
-                }
-            }
-        }
-
-        return true;
     }
 
     // Returns true if a path consisting of undirected and directed edges toward 'to' exists of

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/FgesOrienter.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/FgesOrienter.java
@@ -883,7 +883,7 @@ public final class FgesOrienter implements GraphSearch, GraphScorer, Reorienter 
 
             // Necessary condition for it to be a clique later (after possible edge removals) is that it be a clique
             // now.
-            if (!isClique(union, graph)) continue;
+            if (!GraphUtils.isClique(union, graph)) continue;
 
             if (existsKnowledge()) {
                 if (!validSetByKnowledge(b, s)) {
@@ -992,7 +992,7 @@ public final class FgesOrienter implements GraphSearch, GraphScorer, Reorienter 
             Set<Node> diff = new HashSet<>(naYX);
             diff.removeAll(h);
 
-            if (!isClique(diff, graph)) continue;
+            if (!GraphUtils.isClique(diff, graph)) continue;
 
             if (existsKnowledge()) {
                 if (!validSetByKnowledge(b, h)) {
@@ -1278,7 +1278,7 @@ public final class FgesOrienter implements GraphSearch, GraphScorer, Reorienter 
     private boolean validDelete(Node y, Set<Node> h, Set<Node> naXY, Graph graph) {
         Set<Node> set = new HashSet<>(naXY);
         set.removeAll(h);
-        return isClique(set, graph) && allNeighbors(y, set, graph);
+        return GraphUtils.isClique(set, graph) && allNeighbors(y, set, graph);
     }
 
     // Adds edges required by knowledge.
@@ -1377,20 +1377,6 @@ public final class FgesOrienter implements GraphSearch, GraphScorer, Reorienter 
         }
 
         return nayx;
-    }
-
-    // Returns true iif the given set forms a clique in the given graph.
-    private static boolean isClique(Set<Node> nodes, Graph graph) {
-        List<Node> _nodes = new ArrayList<>(nodes);
-        for (int i = 0; i < _nodes.size() - 1; i++) {
-            for (int j = i + 1; j < _nodes.size(); j++) {
-                if (!graph.isAdjacentTo(_nodes.get(i), _nodes.get(j))) {
-                    return false;
-                }
-            }
-        }
-
-        return true;
     }
 
     // Returns true is a path consisting of undirected and directed edges toward 'to' exists of

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/TsFges2.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/TsFges2.java
@@ -1109,7 +1109,7 @@ public final class TsFges2 implements GraphSearch, GraphScorer {
         }
 
         Set<Node> naYX = getNaYX(a, b);
-        if (!isClique(naYX)) return;
+        if (!GraphUtils.isClique(naYX, this.graph)) return;
 
         List<Node> TNeighbors = getTNeighbors(a, b);
         int _maxIndegree = maxIndegree == -1 ? 1000 : maxIndegree;
@@ -1144,7 +1144,7 @@ public final class TsFges2 implements GraphSearch, GraphScorer {
                     break FOR;
                 }
 
-                if (!isClique(union)) continue;
+                if (!GraphUtils.isClique(union, this.graph)) continue;
                 newCliques.add(union);
 
                 double bump = insertEval(a, b, T, naYX, hashIndices);
@@ -1567,7 +1567,7 @@ public final class TsFges2 implements GraphSearch, GraphScorer {
 
         Set<Node> union = new HashSet<>(T);
         union.addAll(naYX);
-        boolean clique = isClique(union);
+        boolean clique = GraphUtils.isClique(union, this.graph);
         boolean noCycle = !existsUnblockedSemiDirectedPath(y, x, union, cycleBound);
         return clique && noCycle && !violatesKnowledge;
     }
@@ -1589,7 +1589,7 @@ public final class TsFges2 implements GraphSearch, GraphScorer {
 
         Set<Node> diff = new HashSet<>(naYX);
         diff.removeAll(H);
-        return isClique(diff) && !violatesKnowledge;
+        return GraphUtils.isClique(diff, this.graph) && !violatesKnowledge;
     }
 
     // Adds edges required by knowledge.
@@ -1682,22 +1682,6 @@ public final class TsFges2 implements GraphSearch, GraphScorer {
         }
 
         return nayx;
-    }
-
-    Set<Edge> cliqueEdges = new HashSet<>();
-
-    // Returns true iif the given set forms a clique in the given graph.
-    private boolean isClique(Set<Node> nodes) {
-        List<Node> _nodes = new ArrayList<>(nodes);
-        for (int i = 0; i < _nodes.size() - 1; i++) {
-            for (int j = i + 1; j < _nodes.size(); j++) {
-                if (!graph.isAdjacentTo(_nodes.get(i), _nodes.get(j))) {
-                    return false;
-                }
-            }
-        }
-
-        return true;
     }
 
     // Returns true if a path consisting of undirected and directed edges toward 'to' exists of


### PR DESCRIPTION
**Summary**
For consistency purposes, we should probably be using `isClique` from `GraphUtils`. I'm new to the project, so let me know if this is a bad idea, or otherwise incorrect.

**Testing**

I tried to test this change by running the [main method in `TestFges.java`](https://github.com/cmu-phil/tetrad/blob/0031bda0387f30996b1180ba17a0aeee69ad44f7/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestFges.java#L1377), but it seems to fail within `printStats(..., t=3,...)` because of this [code block](https://github.com/cmu-phil/tetrad/blob/0031bda0387f30996b1180ba17a0aeee69ad44f7/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestFges.java#L1009):

```
        switch (t) {
                case 0:
                    out = searchSemFges(data, penalty);
                    break;
                case 1:
                    out = searchBdeuFges(data, numCategories);
                    break;
                case 2:
                    out = searchMixedFges(data, penalty);
                    break;
                case 6:
                    out = searchMGMFges(data, penalty);
                    break;
                default:
                    throw new IllegalStateException();
            }
```

Full Stack Trace:

```
Exception in thread "main" java.lang.IllegalStateException
	at edu.cmu.tetrad.test.TestFges.printStats(TestFges.java:1027)
	at edu.cmu.tetrad.test.TestFges.testBestAlgorithms(TestFges.java:941)
	at edu.cmu.tetrad.test.TestFges.main(TestFges.java:1381)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:483)
	at com.intellij.rt.execution.application.AppMain.main(AppMain.java:134)
```

Of course, this is an unrelated issue (though I'd appreciate any suggestions on how to test changes).