### PR TITLE
Fixed #695 by using tooltip

### DIFF
--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/SemImEditor.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/SemImEditor.java
@@ -743,8 +743,7 @@ public final class SemImEditor extends JPanel implements LayoutEditable, DoNotSc
                         // from the text field they are editing without the
                         // textfield disappearing. jdramsey 3/16/2005.
 //                    resetLabels();
-                        ToolTipManager toolTipManager
-                                = ToolTipManager.sharedInstance();
+                        ToolTipManager toolTipManager = ToolTipManager.sharedInstance();
                         toolTipManager.setInitialDelay(100);
                     }
                 }
@@ -752,8 +751,7 @@ public final class SemImEditor extends JPanel implements LayoutEditable, DoNotSc
                 @Override
                 public void mouseExited(MouseEvent e) {
                     if (!workbench().contains(e.getPoint())) {
-                        ToolTipManager toolTipManager
-                                = ToolTipManager.sharedInstance();
+                        ToolTipManager toolTipManager = ToolTipManager.sharedInstance();
                         toolTipManager.setInitialDelay(getSavedTooltipDelay());
                     }
                 }
@@ -1113,7 +1111,9 @@ public final class SemImEditor extends JPanel implements LayoutEditable, DoNotSc
                 label.setBackground(Color.white);
                 label.setOpaque(true);
                 label.setFont(SMALL_FONT);
+                
                 label.setText(" " + asString(val) + " ");
+                
                 label.setToolTipText(parameter.getName() + " = " + asString(val));
                 label.addMouseListener(new EdgeMouseListener(edge, this));
                 if (!Double.isNaN(standardError) && semIm().isEstimated()) {

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/StandardizedSemImGraphicalEditor.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/StandardizedSemImGraphicalEditor.java
@@ -26,18 +26,17 @@ import edu.cmu.tetrad.sem.StandardizedSemIm;
 import edu.cmu.tetrad.util.NumberFormatUtil;
 import edu.cmu.tetradapp.util.DoubleTextField;
 import edu.cmu.tetradapp.workbench.GraphWorkbench;
-
-import javax.swing.*;
-import javax.swing.border.EmptyBorder;
-import javax.swing.border.TitledBorder;
-import javax.swing.event.ChangeEvent;
-import javax.swing.event.ChangeListener;
 import java.awt.*;
 import java.awt.event.*;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.text.NumberFormat;
 import java.util.List;
+import javax.swing.*;
+import javax.swing.border.EmptyBorder;
+import javax.swing.border.TitledBorder;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
 
 
 /**
@@ -240,16 +239,14 @@ final class StandardizedSemImGraphicalEditor extends JPanel {
                     // from the text field they are editing without the
                     // textfield disappearing. jdramsey 3/16/2005.
 //                    resetLabels();
-                    ToolTipManager toolTipManager =
-                            ToolTipManager.sharedInstance();
+                    ToolTipManager toolTipManager = ToolTipManager.sharedInstance();
                     toolTipManager.setInitialDelay(100);
                 }
             }
 
             public void mouseExited(MouseEvent e) {
                 if (!workbench().contains(e.getPoint())) {
-                    ToolTipManager toolTipManager =
-                            ToolTipManager.sharedInstance();
+                    ToolTipManager toolTipManager = ToolTipManager.sharedInstance();
                     toolTipManager.setInitialDelay(getSavedTooltipDelay());
                 }
             }

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/workbench/AbstractWorkbench.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/workbench/AbstractWorkbench.java
@@ -64,9 +64,7 @@ import java.util.Set;
 import java.util.prefs.Preferences;
 import javax.swing.AbstractAction;
 import javax.swing.Action;
-import javax.swing.BorderFactory;
 import javax.swing.JComponent;
-import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPopupMenu;
 import javax.swing.KeyStroke;
@@ -577,16 +575,16 @@ public abstract class AbstractWorkbench extends JComponent implements WorkbenchM
 	 */
 	public final void setEdgeLabel(Edge modelEdge, JComponent label) {
 		if (modelEdge == null) {
-			throw new NullPointerException("Attempt to set a label on a " + "null model edge: " + modelEdge);
+		    throw new NullPointerException("Attempt to set a label on a " + "null model edge: " + modelEdge);
 		} else if (!getModelEdgesToDisplay().containsKey(modelEdge)) {
-			throw new IllegalArgumentException(
-					"Attempt to set a label on " + "a model edge that's not " + "in the editor: " + modelEdge);
+		    throw new IllegalArgumentException("Attempt to set a label on " + "a model edge that's not " + "in the editor: " + modelEdge);
 		}
 
 		// retrieve display edge from map, or create one if not
 		// there...
 		DisplayEdge displayEdge = (DisplayEdge) getModelEdgesToDisplay().get(modelEdge);
-		GraphEdgeLabel oldLabel = getEdgeLabel(displayEdge);
+                
+                GraphEdgeLabel oldLabel = getEdgeLabel(displayEdge);
 
 		if (oldLabel != null) {
 			remove(oldLabel);
@@ -603,6 +601,24 @@ public abstract class AbstractWorkbench extends JComponent implements WorkbenchM
 		repaint();
 	}
 
+        /**
+         * Edge tooltip to show the edge type and probabilities - Added by Zhou
+         * 
+         * @param modelEdge
+         * @param toolTipText 
+         */
+        public final void setEdgeToolTip(Edge modelEdge, String toolTipText) {
+		if (modelEdge == null) {
+		    throw new NullPointerException("Attempt to set a label on a " + "null model edge: " + modelEdge);
+		} else if (!getModelEdgesToDisplay().containsKey(modelEdge)) {
+		    throw new IllegalArgumentException("Attempt to set a label on " + "a model edge that's not " + "in the editor: " + modelEdge);
+		}
+
+		DisplayEdge displayEdge = (DisplayEdge) getModelEdgesToDisplay().get(modelEdge);
+
+                displayEdge.setToolTipText(toolTipText);
+	}
+        
 	/**
 	 * Sets the label for a node to a particular JComponent. The label will be
 	 * displayed slightly off to the right of the node.
@@ -2114,17 +2130,19 @@ public abstract class AbstractWorkbench extends JComponent implements WorkbenchM
 						case "Star" : endpoint1 = "&#42;"; break;
 						case "Null" : endpoint1 = "Null"; break;
 					}
+                                        
 					String endpoint2 = edge.getEndpoint2().toString();
 					switch(endpoint2){
-					case "Tail" : endpoint2 = "-"; break;
-					case "Arrow" : endpoint2 = "&gt;"; break;
-					case "Circle" : endpoint2 = "o"; break;
-					case "Star" : endpoint2 = "&#42;"; break;
-					case "Null" : endpoint2 = "Null"; break;
-				}
-					String text = "<html><b>" + edge.getNode1().getName() + 
+                                            case "Tail" : endpoint2 = "-"; break;
+                                            case "Arrow" : endpoint2 = "&gt;"; break;
+                                            case "Circle" : endpoint2 = "o"; break;
+                                            case "Star" : endpoint2 = "&#42;"; break;
+                                            case "Null" : endpoint2 = "Null"; break;
+                                        }
+                                        
+					String text = "<html>" + edge.getNode1().getName() + 
 							" " + endpoint1 + "-" + endpoint2 + " " + 
-							edge.getNode2().getName() + "</b><br>";
+							edge.getNode2().getName() + "<br>";
 					String n1 = edge.getNode1().getName();
 					String n2 = edge.getNode2().getName();
 					List<String> nodes = new ArrayList<>();
@@ -2173,30 +2191,36 @@ public abstract class AbstractWorkbench extends JComponent implements WorkbenchM
 							text += "<br>";
 						}
 					}
-					JLabel edgeTypeDistLabel = new JLabel(text);
-					edgeTypeDistLabel.setOpaque(true);
-					edgeTypeDistLabel.setBorder(BorderFactory.createLineBorder(Color.BLACK));
-					setEdgeLabel(edge, edgeTypeDistLabel);
 
+                                        // Commented out by Zhou
+//					JLabel edgeTypeDistLabel = new JLabel(text);
+//					edgeTypeDistLabel.setOpaque(true);
+//					edgeTypeDistLabel.setBorder(BorderFactory.createLineBorder(Color.BLACK));
+//					setEdgeLabel(edge, edgeTypeDistLabel);
+
+                                        // Use tooltip instead of label - Added by Zhou
+                                        setEdgeToolTip(edge, text);
 				}
 			}
 		}
 	}
 
-	private void handleMouseExited(MouseEvent e) {
-		Object source = e.getSource();
-
-		if (source instanceof DisplayEdge) {
-			IDisplayEdge displayEdge = (IDisplayEdge) source;
-			Edge edge = displayEdge.getModelEdge();
-			if (graph.containsEdge(edge)) {
-				List<EdgeTypeProbability> edgeProb = edge.getEdgeTypeProbabilities();
-				if (edgeProb != null) {
-					setEdgeLabel(edge, null);
-				}
-			}
-		}
-	}
+        // SInce we use tooltip to show edge type and probablitites, 
+        // we no longer need this call. - Commented out by Zhou
+//	private void handleMouseExited(MouseEvent e) {
+//		Object source = e.getSource();
+//
+//		if (source instanceof DisplayEdge) {
+//			IDisplayEdge displayEdge = (IDisplayEdge) source;
+//			Edge edge = displayEdge.getModelEdge();
+//			if (graph.containsEdge(edge)) {
+//				List<EdgeTypeProbability> edgeProb = edge.getEdgeTypeProbabilities();
+//				if (edgeProb != null) {
+//					setEdgeLabel(edge, null);
+//				}
+//			}
+//		}
+//	}
 
 	private void snapSingleNodeFromNegative(Object source) {
 		DisplayNode node = (DisplayNode) source;
@@ -2722,7 +2746,8 @@ public abstract class AbstractWorkbench extends JComponent implements WorkbenchM
 		}
 
 		public final void mouseExited(MouseEvent e) {
-			workbench.handleMouseExited(e);
+                    // Commented out by Zhou
+			//workbench.handleMouseExited(e);
 		}
 	}
 


### PR DESCRIPTION
This pull request addressed the issue #695 by showing the edge type and probabilities in a tooltip instead of JLabel when mouse over the edge in a graph.

I've also commented out the old code instead of deleting for future reference in case being used by any other components.

@jdramsey @kvb2univpitt please check this out and merge if looking good. Thanks!