### PR TITLE
Addressed issue #795 to create new simulation on each new click

### DIFF
--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/model/Simulation.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/model/Simulation.java
@@ -272,9 +272,11 @@ public class Simulation extends DataWrapper implements SessionModel,
     }
 
     public void createSimulation() {
-        if (simulation.getNumDataModels() == 0) {
+        // Every time the users click the Simulate button, new data needs to be created
+        // regardless of already created data - Zhou
+        //if (simulation.getNumDataModels() == 0) {
             simulation.createData(parameters);
-        }
+        //}
     }
 
     @Override


### PR DESCRIPTION
In the current simulation implementation, once the simulated data is generated, clicking the "Simulate" button again doesn't regenerate the data. Fixed this.

