### PR TITLE
Fixed graph editor layout on full screen

### DIFF
--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/DagEditor.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/DagEditor.java
@@ -238,14 +238,15 @@ public final class DagEditor extends JPanel
         
         // topBox Left side toolbar
         DagGraphToolbar graphToolbar = new DagGraphToolbar(getWorkbench());
+        graphToolbar.setMaximumSize(new Dimension(140, 450));
         
         // topBox right side graph editor
-        
         graphEditorScroll.setPreferredSize(new Dimension(760, 450));
         graphEditorScroll.setViewportView(workbench);
 
         // topBox contains the topGraphBox and the instructionBox underneath
         Box topBox = Box.createVerticalBox();
+        topBox.setPreferredSize(new Dimension(820, 400));
         
         // topGraphBox contains the vertical graph toolbar and graph editor
         Box topGraphBox = Box.createHorizontalBox();
@@ -254,6 +255,7 @@ public final class DagEditor extends JPanel
 
         // Instruction with info button 
         Box instructionBox = Box.createHorizontalBox();
+        instructionBox.setMaximumSize(new Dimension(820, 40));
         
         JLabel label = new JLabel("Double click variable/node rectangle to change name. More information on graph edge types");
         label.setFont(new Font("SansSerif", Font.PLAIN, 12));

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/GeneralAlgorithmEditor.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/GeneralAlgorithmEditor.java
@@ -1263,9 +1263,7 @@ public class GeneralAlgorithmEditor extends JPanel implements FinalizingEditor {
     private JSplitPane createSearchResultPane(Graph graph) {
         // topBox contains the graphEditorScroll and the instructionBox underneath
         Box topBox = Box.createVerticalBox();       
-        //topBox.setPreferredSize(new Dimension(820, 450));
-        topBox.setMinimumSize(new Dimension(820, 400));
-        //topBox.setMaximumSize(new Dimension(820, 400));
+        topBox.setPreferredSize(new Dimension(820, 400));
  
         // topBox graph editor
         JScrollPane graphEditorScroll = new JScrollPane();

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/GraphEditor.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/GraphEditor.java
@@ -225,6 +225,7 @@ public final class GraphEditor extends JPanel
         
         // topBox Left side toolbar
         GraphToolbar graphToolbar = new GraphToolbar(getWorkbench());
+        graphToolbar.setMaximumSize(new Dimension(140, 450));
         
         // topBox right side graph editor
         graphEditorScroll.setPreferredSize(new Dimension(760, 450));
@@ -232,6 +233,7 @@ public final class GraphEditor extends JPanel
 
         // topBox contains the topGraphBox and the instructionBox underneath
         Box topBox = Box.createVerticalBox();
+        topBox.setPreferredSize(new Dimension(820, 400));
         
         // topGraphBox contains the vertical graph toolbar and graph editor
         Box topGraphBox = Box.createHorizontalBox();
@@ -240,6 +242,7 @@ public final class GraphEditor extends JPanel
 
         // Instruction with info button 
         Box instructionBox = Box.createHorizontalBox();
+        instructionBox.setMaximumSize(new Dimension(820, 40));
         
         JLabel label = new JLabel("Double click variable/node rectangle to change name. More information on graph edge types");
         label.setFont(new Font("SansSerif", Font.PLAIN, 12));

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/SemGraphEditor.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/SemGraphEditor.java
@@ -245,14 +245,15 @@ public final class SemGraphEditor extends JPanel
         
         // topBox Left side toolbar
         SemGraphToolbar graphToolbar = new SemGraphToolbar(getWorkbench());
+        graphToolbar.setMaximumSize(new Dimension(140, 450));
         
         // topBox right side graph editor
-        
         graphEditorScroll.setPreferredSize(new Dimension(760, 450));
         graphEditorScroll.setViewportView(workbench);
 
         // topBox contains the topGraphBox and the instructionBox underneath
         Box topBox = Box.createVerticalBox();
+        topBox.setPreferredSize(new Dimension(820, 400));
         
         // topGraphBox contains the vertical graph toolbar and graph editor
         Box topGraphBox = Box.createHorizontalBox();
@@ -261,6 +262,7 @@ public final class SemGraphEditor extends JPanel
 
         // Instruction with info button 
         Box instructionBox = Box.createHorizontalBox();
+        instructionBox.setMaximumSize(new Dimension(820, 40));
         
         JLabel label = new JLabel("Double click variable/node rectangle to change name. More information on graph edge types");
         label.setFont(new Font("SansSerif", Font.PLAIN, 12));

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/TimeLagGraphEditor.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/TimeLagGraphEditor.java
@@ -237,14 +237,15 @@ public final class TimeLagGraphEditor extends JPanel
    
         // topBox Left side toolbar
         DagGraphToolbar graphToolbar = new DagGraphToolbar(getWorkbench());
+        graphToolbar.setMaximumSize(new Dimension(140, 450));
         
         // topBox right side graph editor
-        
         graphEditorScroll.setPreferredSize(new Dimension(760, 450));
         graphEditorScroll.setViewportView(workbench);
 
         // topBox contains the topGraphBox and the instructionBox underneath
         Box topBox = Box.createVerticalBox();
+        topBox.setPreferredSize(new Dimension(820, 400));
         
         // topGraphBox contains the vertical graph toolbar and graph editor
         Box topGraphBox = Box.createHorizontalBox();
@@ -253,6 +254,7 @@ public final class TimeLagGraphEditor extends JPanel
 
         // Instruction with info button 
         Box instructionBox = Box.createHorizontalBox();
+        instructionBox.setMaximumSize(new Dimension(820, 40));
         
         JLabel label = new JLabel("Double click variable/node rectangle to change name. More information on graph edge types");
         label.setFont(new Font("SansSerif", Font.PLAIN, 12));


### PR DESCRIPTION
This pull request fixed the big empty spaces in graph editor between the left-side toolbar and the right-side graph display. It also made the resize of bootstrap table more flexible.

