### PR TITLE
Subgraph tweak zhou

### DIFF
--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/model/GraphSelectionWrapper.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/model/GraphSelectionWrapper.java
@@ -117,17 +117,18 @@ public class GraphSelectionWrapper implements SessionModel, GraphSource, Knowled
             GraphUtils.fruchtermanReingoldLayout(graph);
         }
 
-        List<Node> nodes = getVariables();
-
-        // Default to select the first 50 variables to render graph
-        List<Node> first50 = new ArrayList<>();
-
-        for (int i = 0; i < 50; i++) {
-            if (i >= nodes.size()) continue;
-            first50.add(nodes.get(i));
-        }
-
-        setSelectedVariables(first50);
+        // No variable is selected by default - Updated 11/19/2018 by Zhou
+//        List<Node> nodes = getVariables();
+//
+//        // Default to select the first 50 variables to render graph
+//        List<Node> first50 = new ArrayList<>();
+//
+//        for (int i = 0; i < 50; i++) {
+//            if (i >= nodes.size()) continue;
+//            first50.add(nodes.get(i));
+//        }
+//
+//        setSelectedVariables(first50);
 
         log();
     }

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/ui/DualListPanel.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/ui/DualListPanel.java
@@ -69,7 +69,7 @@ public class DualListPanel extends JPanel {
 
         setOpaque(false);
 
-        unselectedScrollPane.setBorder(BorderFactory.createTitledBorder("Unselected"));
+        unselectedScrollPane.setBorder(BorderFactory.createTitledBorder("Not selected"));
 
         unselectedScrollPane.setViewportView(sourceList);
 


### PR DESCRIPTION
Before this change, in the subgraph selection editor, the first 50 variables are selected by default. Based on feedback from the Puerto Rico meeting, this is confusing to users. So I changed it to have all the variables deselected by default. Once the users select some variables and hit the "Graph It!" button, they'll see the graph of selected variables on the right.

![capture](https://user-images.githubusercontent.com/195873/48784058-e29a6000-ecaf-11e8-94ea-c5da5800a61f.PNG)
![capture2](https://user-images.githubusercontent.com/195873/48784060-e4642380-ecaf-11e8-9ed1-ba9037851164.PNG)

