### PR TITLE
Algo chooser restore states zhou

### DIFF
--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/app/SessionEditorNode.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/app/SessionEditorNode.java
@@ -974,7 +974,7 @@ public final class SessionEditorNode extends DisplayNode {
                 SessionEditorWorkbench workbench
                         = (SessionEditorWorkbench) container;
 
-                System.out.println("Executing" + sessionNode);
+                System.out.println("Executing " + sessionNode);
 
                 workbench.getSimulationStudy().execute(sessionNode, overwrite);
             }

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/model/GeneralAlgorithmRunner.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/model/GeneralAlgorithmRunner.java
@@ -74,7 +74,7 @@ public class GeneralAlgorithmRunner implements AlgorithmRunner, ParamsResettable
     private Graph initialGraph;
     private List<Graph> graphList = new ArrayList<>();
     private IKnowledge knowledge = new Knowledge2();
-    private final Map<String, Object> models = new HashMap<>();
+    private final Map<String, Object> userAlgoSelections = new HashMap<>();
     private transient List<IndependenceTest> independenceTests = null;
 
     //===========================CONSTRUCTORS===========================//
@@ -302,8 +302,7 @@ public class GeneralAlgorithmRunner implements AlgorithmRunner, ParamsResettable
                     } else if (data.isMixed() && algDataType == DataType.Mixed) {
                         graphList.add(algo.search(data, parameters));
                     } else {
-                        throw new IllegalArgumentException("The type of data changed; try opening up the search editor and "
-                                + "running the algorithm there.");
+                        throw new IllegalArgumentException("The type of data has changed; open up the search editor and run the algorithm again.");
                     }
                 });
             }
@@ -529,8 +528,8 @@ public class GeneralAlgorithmRunner implements AlgorithmRunner, ParamsResettable
         return compareGraphs;
     }
 
-    public Map<String, Object> getModels() {
-        return models;
+    public Map<String, Object> getUserAlgoSelections() {
+        return userAlgoSelections;
     }
 
 }

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/Algorithm.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/Algorithm.java
@@ -1,14 +1,11 @@
 package edu.cmu.tetrad.algcomparison.algorithm;
 
-import edu.cmu.tetrad.algcomparison.simulation.Simulation;
-import edu.cmu.tetrad.data.DataModel;
-import edu.cmu.tetrad.util.Parameters;
 import edu.cmu.tetrad.algcomparison.utils.HasParameters;
-import edu.cmu.tetrad.data.DataSet;
+import edu.cmu.tetrad.data.DataModel;
 import edu.cmu.tetrad.data.DataType;
 import edu.cmu.tetrad.graph.Graph;
+import edu.cmu.tetrad.util.Parameters;
 import edu.cmu.tetrad.util.TetradSerializable;
-
 import java.util.List;
 
 /**

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/pag/Gfci.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/pag/Gfci.java
@@ -14,7 +14,6 @@ import edu.cmu.tetrad.search.GFci;
 import edu.cmu.tetrad.util.Parameters;
 import edu.pitt.dbmi.algo.resampling.GeneralResamplingTest;
 import edu.pitt.dbmi.algo.resampling.ResamplingEdgeEnsemble;
-
 import java.io.PrintStream;
 import java.util.List;
 
@@ -46,7 +45,7 @@ public class Gfci implements Algorithm, HasKnowledge, UsesScoreWrapper, TakesInd
     @Override
     public Graph search(DataModel dataSet, Parameters parameters) {
     	if (parameters.getInt("numberResampling") < 1) {
-            GFci search = new GFci(test.getTest(dataSet, parameters), score.getScore(dataSet, parameters));
+            GFci search = new GFci(test.getTest(dataSet, parameters), score.getScore(dataSet, parameters));  
             search.setMaxDegree(parameters.getInt("maxDegree"));
             search.setKnowledge(knowledge);
             search.setVerbose(parameters.getBoolean("verbose"));


### PR DESCRIPTION
This pull request addressed the issue #936 

In short this behavior would happen if we make changes to the upstream nodes. For example we did a search from a simulated data, then we change the simulation. Because a new algo runner is created, we lose the user selections on the algo chooser UI.

When the data type is changed in upstream nodes, Tetrad will popup a message window to ask users to run the search again. In this case, all user selections are rest to the default.

When changes can still be populated to the search box and a new search with the same algorithm (test & score) created, we could still restore the selected algo name (from the search result) in UI to avoid any confusions. But the selected test and score are not being restored in this fix, due to inconsistency of algorithm implementations. We'll work on that after the release.

@espinoj @kvb2univpitt @jdramsey please review. Thanks!