### PR TITLE
Fixes to gen sim, gen pm, gen im.

### DIFF
--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/simulation/GeneralSemSimulation.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/simulation/GeneralSemSimulation.java
@@ -5,12 +5,15 @@ import edu.cmu.tetrad.algcomparison.graph.SingleGraph;
 import edu.cmu.tetrad.data.DataModel;
 import edu.cmu.tetrad.data.DataSet;
 import edu.cmu.tetrad.data.DataType;
+import edu.cmu.tetrad.data.DataUtils;
 import edu.cmu.tetrad.graph.Graph;
 import edu.cmu.tetrad.graph.Node;
-import edu.cmu.tetrad.graph.NodeType;
 import edu.cmu.tetrad.graph.SemGraph;
-import edu.cmu.tetrad.sem.*;
+import edu.cmu.tetrad.sem.GeneralizedSemIm;
+import edu.cmu.tetrad.sem.GeneralizedSemPm;
+import edu.cmu.tetrad.sem.TemplateExpander;
 import edu.cmu.tetrad.util.Parameters;
+import edu.cmu.tetrad.util.RandomUtil;
 
 import java.text.ParseException;
 import java.util.ArrayList;
@@ -22,11 +25,12 @@ import java.util.List;
 public class GeneralSemSimulation implements Simulation {
     static final long serialVersionUID = 23L;
     private RandomGraph randomGraph;
-    private List<DataSet> dataSets = new ArrayList<>();
-    private List<Graph> graphs = new ArrayList<>();
     private GeneralizedSemPm pm;
-    private List<GeneralizedSemIm> ims;
-    private GeneralizedSemIm im = null;
+    private GeneralizedSemIm im;
+    private List<DataSet> dataSets = new ArrayList<>();
+    private List<DataSet> dataWithLatents = new ArrayList<>();
+    private List<Graph> graphs = new ArrayList<>();
+    private List<GeneralizedSemIm> ims = new ArrayList<>();
 
     public GeneralSemSimulation(RandomGraph graph) {
         this.randomGraph = graph;
@@ -52,10 +56,10 @@ public class GeneralSemSimulation implements Simulation {
     @Override
     public void createData(Parameters parameters) {
         Graph graph = randomGraph.createGraph(parameters);
-        ims = new ArrayList<>();
 
         dataSets = new ArrayList<>();
         graphs = new ArrayList<>();
+        ims = new ArrayList<>();
 
         for (int i = 0; i < parameters.getInt("numRuns"); i++) {
             System.out.println("Simulating dataset #" + (i + 1));
@@ -67,27 +71,46 @@ public class GeneralSemSimulation implements Simulation {
             graphs.add(graph);
 
             DataSet dataSet = simulate(graph, parameters);
+
+            if (parameters.getBoolean("standardize")) {
+                dataSet = DataUtils.standardizeData(dataSet);
+            }
+
+            double variance = parameters.getDouble("measurementVariance");
+
+            if (variance > 0) {
+                for (int k = 0; k < dataSet.getNumRows(); k++) {
+                    for (int j = 0; j < dataSet.getNumColumns(); j++) {
+                        double d = dataSet.getDouble(k, j);
+                        double norm = RandomUtil.getInstance().nextNormal(0, Math.sqrt(variance));
+                        dataSet.setDouble(k, j, d + norm);
+                    }
+                }
+            }
+
+            if (parameters.getBoolean("randomizeColumns")) {
+                dataSet = DataUtils.reorderColumns(dataSet);
+            }
+
             dataSet.setName("" + (i + 1));
-            dataSets.add(dataSet);
+            dataSets.add(DataUtils.restrictToMeasured(dataSet));
+            dataWithLatents.add(dataSet);
         }
     }
 
-    private DataSet simulate(Graph graph, Parameters parameters) {
-        if (im == null) {
-            if (pm == null) {
-                pm = new GeneralizedSemPm(graph);
-                im = new GeneralizedSemIm(pm);
-                ims.add(im);
-                return im.simulateData(parameters.getInt("sampleSize"), false);
-            } else {
-                im = new GeneralizedSemIm(pm);
-                ims.add(im);
-                return im.simulateData(parameters.getInt("sampleSize"), false);
-            }
-        } else {
-            ims.add(im);
-            return im.simulateData(parameters.getInt("sampleSize"), false);
+    private synchronized DataSet simulate(Graph graph, Parameters parameters) {
+        if (pm == null) {
+            pm = getPm(graph, parameters);
         }
+
+        System.out.println(pm);
+
+        im = new GeneralizedSemIm(pm);
+
+        System.out.println(im);
+
+        ims.add(im);
+        return im.simulateData(parameters.getInt("sampleSize"), true);
     }
 
     @Override
@@ -139,27 +162,28 @@ public class GeneralSemSimulation implements Simulation {
         List<Node> variablesNodes = pm.getVariableNodes();
         List<Node> errorNodes = pm.getErrorNodes();
 
-        String measuredFunction = parameters.getString("generalSemFunctionTemplateMeasured");
-        String latentFunction = parameters.getString("generalSemFunctionTemplateLatent");
-        String error = parameters.getString("generalSemErrorTemplate");
-
         try {
+
             for (Node node : variablesNodes) {
-                if (node.getNodeType() == NodeType.LATENT) {
-                    String _template = TemplateExpander.getInstance().expandTemplate(
-                            latentFunction, pm, node);
-                    pm.setNodeExpression(node, _template);
-                } else {
-                    String _template = TemplateExpander.getInstance().expandTemplate(
-                            measuredFunction, pm, node);
-                    pm.setNodeExpression(node, _template);
-                }
+                String _template = TemplateExpander.getInstance().expandTemplate(
+                        parameters.getString("generalSemFunctionTemplateMeasured"), pm, node);
+                pm.setNodeExpression(node, _template);
             }
 
             for (Node node : errorNodes) {
-                String _template = TemplateExpander.getInstance().expandTemplate(error, pm, node);
+                String _template = TemplateExpander.getInstance().expandTemplate(
+                        parameters.getString("generalSemErrorTemplate"), pm, node);
                 pm.setNodeExpression(node, _template);
             }
+
+            for (String parameter : pm.getParameters()) {
+                pm.setParameterExpression(parameter, parameters.getString("generalSemParameterTemplate"));
+            }
+
+            pm.setVariablesTemplate(parameters.getString("generalSemFunctionTemplateMeasured"));
+            pm.setErrorsTemplate(parameters.getString("generalSemErrorTemplate"));
+            pm.setParametersTemplate(parameters.getString("generalSemParameterTemplate"));
+
         } catch (ParseException e) {
             System.out.println(e);
         }

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/sem/GeneralizedSemPm.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/sem/GeneralizedSemPm.java
@@ -134,12 +134,12 @@ public final class GeneralizedSemPm implements PM, TetradSerializable {
     /**
      * The stored template for freeParameters.
      */
-    private String parametersTemplate = "Split(-1.5,-.5,.5,1.5)";
+    private String parametersTemplate = "Split(-1.0,-.5,.5,1.0)";
 
     /**
      * The stored template for freeParameters.
      */
-    private String parametersEstimationInitializationTemplate = "Split(-1.5,-.5,.5,1.5)";
+    private String parametersEstimationInitializationTemplate = "Split(-1.0,-.5,.5,1.0)";
 
     /**
      * The list of variable names.
@@ -281,7 +281,7 @@ public final class GeneralizedSemPm implements PM, TetradSerializable {
                         setParametersTemplate(expressionString);
                     }
                     else {
-                        String expressionString = "Split(-1.5, -.5, .5, 1.5)";
+                        String expressionString = "Split(-1.0, -.5, .5, 1.0)";
                         setParameterExpression(parameter, expressionString);
                         setParametersTemplate(expressionString);
                     }
@@ -299,11 +299,11 @@ public final class GeneralizedSemPm implements PM, TetradSerializable {
                         setParameterEstimationInitializationExpression(parameter, expressionString);
                     }
                     else {
-                        String expressionString = "Split(-1.5, -.5, .5, 1.5)";
+                        String expressionString = "Split(-1.0, -.5, .5, 1.0)";
                         setParameterEstimationInitializationExpression(parameter, expressionString);
                     }
 
-                    setStartsWithParametersTemplate("s","Split(-1.5, -.5, .5, 1.5)");
+                    setStartsWithParametersTemplate("s","Split(-105, -.5, .5, 1.0)");
                     setStartsWithParametersEstimationInitializaationTemplate("s", "Split(-1.5, -.5, .5, 1.5)");
                 }
             }
@@ -450,6 +450,7 @@ public final class GeneralizedSemPm implements PM, TetradSerializable {
         parameters.add("generalSemFunctionTemplateMeasured");
         parameters.add("generalSemFunctionTemplateLatent");
         parameters.add("generalSemErrorTemplate");
+        parameters.add("generalSemParameterTemplate");
         return parameters;
     }
 


### PR DESCRIPTION
This fixes a structural bug in GeneralizedSimulation, which Peter and I discovered the other day. It's supposed to be the case that you can build data->generalized PM->generalized IM->Simulation and simulate data from the IM that you build. But it was substituting a new, random IM instead. I just had to put back some code that was there before. A few corrections are also made to GeneralizedSemPm and GeneralizedSemIm.

@espinoj @yuanzhou 