### PR TITLE
V6.7.0 function to disable graph editing

### DIFF
--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/GeneralAlgorithmEditor.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/GeneralAlgorithmEditor.java
@@ -1294,10 +1294,13 @@ public class GeneralAlgorithmEditor extends JPanel implements FinalizingEditor {
         Box topBox = Box.createVerticalBox();
         topBox.setPreferredSize(new Dimension(820, 400));
 
+        GraphWorkbench graphWorkbench = new GraphWorkbench(graph);
+        graphWorkbench.enableEditing(false);
+
         // topBox graph editor
         JScrollPane graphEditorScroll = new JScrollPane();
         graphEditorScroll.setPreferredSize(new Dimension(820, 420));
-        graphEditorScroll.setViewportView(new GraphWorkbench(graph));
+        graphEditorScroll.setViewportView(graphWorkbench);
 
         // Instruction with info button
         Box instructionBox = Box.createHorizontalBox();

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/workbench/AbstractWorkbench.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/workbench/AbstractWorkbench.java
@@ -22,6 +22,7 @@ package edu.cmu.tetradapp.workbench;
 
 import edu.cmu.tetrad.data.IKnowledge;
 import edu.cmu.tetrad.graph.Edge;
+import edu.cmu.tetrad.graph.Edge.Property;
 import edu.cmu.tetrad.graph.EdgeListGraph;
 import edu.cmu.tetrad.graph.EdgeTypeProbability;
 import edu.cmu.tetrad.graph.Edges;
@@ -31,7 +32,6 @@ import edu.cmu.tetrad.graph.GraphNode;
 import edu.cmu.tetrad.graph.GraphUtils;
 import edu.cmu.tetrad.graph.Node;
 import edu.cmu.tetrad.graph.NodeType;
-import edu.cmu.tetrad.graph.Edge.Property;
 import edu.cmu.tetrad.util.JOptionUtils;
 import edu.cmu.tetradapp.model.SessionWrapper;
 import edu.cmu.tetradapp.util.LayoutEditable;
@@ -70,8 +70,6 @@ import javax.swing.JOptionPane;
 import javax.swing.JPopupMenu;
 import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
-
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * The functionality of the workbench which is shared between the workbench
@@ -1070,20 +1068,20 @@ public abstract class AbstractWorkbench extends JComponent implements WorkbenchM
         }
 
         // Create a graph's legend
-        if(graph.getAllAttributes().size() > 0) {
-        	int maxX = getMaxX();
-        	int maxY = getMaxY();
-        	
-        	int margin = 5;
-        	
-        	DisplayLegend legend = new DisplayLegend(graph.getAllAttributes());        	
+        if (graph.getAllAttributes().size() > 0) {
+            int maxX = getMaxX();
+            int maxY = getMaxY();
+
+            int margin = 5;
+
+            DisplayLegend legend = new DisplayLegend(graph.getAllAttributes());
             legend.setLocation(margin, margin);
 
             // add the display node
             add(legend, 0);
 
         }
-        
+
         revalidate();
         repaint();
     }
@@ -2163,18 +2161,18 @@ public abstract class AbstractWorkbench extends JComponent implements WorkbenchM
                             endpoint2 = "Null";
                             break;
                     }
-                    
+
                     String properties = "";
-        			if(edge.getProperties() != null && edge.getProperties().size() > 0) {
-        	        	for(Property property : edge.getProperties()) {
-        	        		properties += " " + property.toString();
-        	        	}
-        	        }
-        			
+                    if (edge.getProperties() != null && edge.getProperties().size() > 0) {
+                        for (Property property : edge.getProperties()) {
+                            properties += " " + property.toString();
+                        }
+                    }
+
                     String text = "<html>" + edge.getNode1().getName()
                             + " " + endpoint1 + "-" + endpoint2 + " "
-                            + edge.getNode2().getName() 
-                            + properties 
+                            + edge.getNode2().getName()
+                            + properties
                             + "<br>";
                     String n1 = edge.getNode1().getName();
                     String n2 = edge.getNode2().getName();
@@ -2220,12 +2218,12 @@ public abstract class AbstractWorkbench extends JComponent implements WorkbenchM
                                 break;
                         }
                         if (edgeTypeProb.getProbability() > 0) {
-                        	properties = "";
-                			if(edgeTypeProb.getProperties() != null && edgeTypeProb.getProperties().size() > 0) {
-                	        	for(Property property : edgeTypeProb.getProperties()) {
-                	        		properties += " " + property.toString();
-                	        	}
-                	        }
+                            properties = "";
+                            if (edgeTypeProb.getProperties() != null && edgeTypeProb.getProperties().size() > 0) {
+                                for (Property property : edgeTypeProb.getProperties()) {
+                                    properties += " " + property.toString();
+                                }
+                            }
                             text += "[" + _type + properties + "]:" + String.format("%.4f", edgeTypeProb.getProbability());
                             text += "<br>";
                         }
@@ -2241,24 +2239,24 @@ public abstract class AbstractWorkbench extends JComponent implements WorkbenchM
                 }
             }
         }
-        
+
         if (source instanceof DisplayNode) {
-        	DisplayNode displayNode = (DisplayNode) source;
+            DisplayNode displayNode = (DisplayNode) source;
             Node node = displayNode.getModelNode();
-            if (graph.containsNode(node)) {	
-            	Map<String, Object> attributes = node.getAllAttributes();
-            	if(!attributes.isEmpty()) {
-            		String attribute = "";
-            		for(String key: attributes.keySet()) {
-            			Object value = attributes.get(key);
-            			
-            			attribute += key + ": " + value + "<br>";
-            		}
-            		
-            		String text = "<html>Node: " + node.getName() + "<br>" + attribute;
-            		
-            		setNodeToolTip(node, text);
-            	}
+            if (graph.containsNode(node)) {
+                Map<String, Object> attributes = node.getAllAttributes();
+                if (!attributes.isEmpty()) {
+                    String attribute = "";
+                    for (String key : attributes.keySet()) {
+                        Object value = attributes.get(key);
+
+                        attribute += key + ": " + value + "<br>";
+                    }
+
+                    String text = "<html>Node: " + node.getName() + "<br>" + attribute;
+
+                    setNodeToolTip(node, text);
+                }
             }
         }
     }

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/workbench/AbstractWorkbench.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/workbench/AbstractWorkbench.java
@@ -270,6 +270,8 @@ public abstract class AbstractWorkbench extends JComponent implements WorkbenchM
      */
     private JComponent currentMouseoverLbl = null;
 
+    private boolean enableEditing = true;
+
     // ==============================CONSTRUCTOR============================//
     /**
      * Constructs a new workbench workbench.
@@ -289,6 +291,7 @@ public abstract class AbstractWorkbench extends JComponent implements WorkbenchM
                 grabFocus();
             }
         });
+        setEnabled(enableEditing);
     }
 
     // ============================PUBLIC METHODS==========================//
@@ -2540,6 +2543,15 @@ public abstract class AbstractWorkbench extends JComponent implements WorkbenchM
         this.deleteVariablesAllowed = deleteVariablesAllowed;
     }
 
+    public boolean isEnableEditing() {
+        return enableEditing;
+    }
+
+    public void enableEditing(boolean enableEditing) {
+        this.enableEditing = enableEditing;
+        setEnabled(enableEditing);
+    }
+
     /**
      * This inner class is a simple wrapper for JComponents which are to serve
      * as edge labels in the workbench. Its sole function is to make sure the
@@ -2738,6 +2750,7 @@ public abstract class AbstractWorkbench extends JComponent implements WorkbenchM
          * Adjusts scrollbars to automatically reflect the position of a
          * component which is being dragged.
          */
+        @Override
         public final void componentMoved(ComponentEvent e) {
             Component source = (Component) e.getSource();
             Rectangle bounds = source.getBounds();
@@ -2769,7 +2782,7 @@ public abstract class AbstractWorkbench extends JComponent implements WorkbenchM
     /**
      * Handles mouse events and mouse motion events.
      */
-    private static final class MouseHandler extends MouseAdapter {
+    private final class MouseHandler extends MouseAdapter {
 
         private final AbstractWorkbench workbench;
 
@@ -2777,22 +2790,33 @@ public abstract class AbstractWorkbench extends JComponent implements WorkbenchM
             this.workbench = workbench;
         }
 
+        @Override
         public final void mouseClicked(MouseEvent e) {
-            workbench.handleMouseClicked(e);
+            if (AbstractWorkbench.this.isEnableEditing()) {
+                workbench.handleMouseClicked(e);
+            }
         }
 
+        @Override
         public final void mousePressed(MouseEvent e) {
             workbench.handleMousePressed(e);
         }
 
+        @Override
         public final void mouseReleased(MouseEvent e) {
-            workbench.handleMouseReleased(e);
+            if (AbstractWorkbench.this.isEnableEditing()) {
+                workbench.handleMouseReleased(e);
+            }
         }
 
+        @Override
         public final void mouseEntered(MouseEvent e) {
-            workbench.handleMouseEntered(e);
+            if (AbstractWorkbench.this.isEnableEditing()) {
+                workbench.handleMouseEntered(e);
+            }
         }
 
+        @Override
         public final void mouseExited(MouseEvent e) {
             // Commented out by Zhou
             //workbench.handleMouseExited(e);
@@ -2807,10 +2831,12 @@ public abstract class AbstractWorkbench extends JComponent implements WorkbenchM
             this.workbench = workbench;
         }
 
+        @Override
         public final void mouseMoved(MouseEvent e) {
             workbench.currentMouseLocation = e.getPoint();
         }
 
+        @Override
         public final void mouseDragged(MouseEvent e) {
             workbench.handleMouseDragged(e);
         }

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/workbench/GraphWorkbench.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/workbench/GraphWorkbench.java
@@ -18,12 +18,21 @@
 // along with this program; if not, write to the Free Software               //
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA //
 ///////////////////////////////////////////////////////////////////////////////
-
 package edu.cmu.tetradapp.workbench;
 
-import edu.cmu.tetrad.graph.*;
+import edu.cmu.tetrad.graph.Edge;
+import edu.cmu.tetrad.graph.EdgeListGraph;
+import edu.cmu.tetrad.graph.Edges;
+import edu.cmu.tetrad.graph.Graph;
+import edu.cmu.tetrad.graph.GraphNode;
+import edu.cmu.tetrad.graph.GraphUtils;
+import edu.cmu.tetrad.graph.Node;
+import edu.cmu.tetrad.graph.NodeType;
+import edu.cmu.tetrad.graph.Triple;
+import edu.cmu.tetrad.graph.TripleClassifier;
 import edu.cmu.tetradapp.model.EditorUtils;
-import java.awt.*;
+import java.awt.Color;
+import java.awt.Point;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
@@ -38,6 +47,8 @@ import java.util.List;
  */
 public class GraphWorkbench extends AbstractWorkbench implements TripleClassifier {
 
+    private static final long serialVersionUID = 938742592547332849L;
+
     //=================PUBLIC STATIC FINAL FIELDS=========================//
     public static final int MEASURED_NODE = 0;
     public static final int LATENT_NODE = 1;
@@ -51,7 +62,6 @@ public class GraphWorkbench extends AbstractWorkbench implements TripleClassifie
     private int edgeMode = DIRECTED_EDGE;
 
     //========================CONSTRUCTORS===============================//
-
     /**
      * Constructs a new workbench with an empty graph; useful if another graph
      * will be set later.
@@ -66,12 +76,9 @@ public class GraphWorkbench extends AbstractWorkbench implements TripleClassifie
     public GraphWorkbench(Graph graph) {
         super(graph);
         setRightClickPopupAllowed(true);
-
-
     }
 
     //========================PUBLIC METHODS==============================//
-
     /**
      * The type of edge to be drawn next.
      *
@@ -107,7 +114,7 @@ public class GraphWorkbench extends AbstractWorkbench implements TripleClassifie
                 modelNode.setNodeType(NodeType.LATENT);
                 break;
 
-            default :
+            default:
                 throw new IllegalStateException();
         }
 
@@ -129,14 +136,11 @@ public class GraphWorkbench extends AbstractWorkbench implements TripleClassifie
             GraphNodeMeasured nodeMeasured = new GraphNodeMeasured(modelNode);
             nodeMeasured.setEditExitingMeasuredVarsAllowed(isEditExistingMeasuredVarsAllowed());
             displayNode = nodeMeasured;
-        }
-        else if (modelNode.getNodeType() == NodeType.LATENT) {
+        } else if (modelNode.getNodeType() == NodeType.LATENT) {
             displayNode = new GraphNodeLatent(modelNode);
-        }
-        else if (modelNode.getNodeType() == NodeType.ERROR) {
+        } else if (modelNode.getNodeType() == NodeType.ERROR) {
             displayNode = new GraphNodeError(modelNode);
-        }
-        else {
+        } else {
             throw new IllegalStateException();
         }
 
@@ -144,8 +148,7 @@ public class GraphWorkbench extends AbstractWorkbench implements TripleClassifie
             public void propertyChange(PropertyChangeEvent evt) {
                 if ("resetGraph".equals(evt.getPropertyName())) {
                     setGraph(getGraph());
-                }
-                else if ("editingValueChanged".equals(evt.getPropertyName())) {
+                } else if ("editingValueChanged".equals(evt.getPropertyName())) {
                     firePropertyChange("modelChanged", null, null);
                 }
             }
@@ -201,17 +204,17 @@ public class GraphWorkbench extends AbstractWorkbench implements TripleClassifie
             case BIDIRECTED_EDGE:
                 return Edges.bidirectedEdge(node1, node2);
 
-            default :
+            default:
                 throw new IllegalStateException();
         }
     }
 
     /**
      * Gets a new "tracking edge"--that is, an edge which is anchored at one end
-     * to a node but tracks the mouse at the other end.  Used for drawing new
+     * to a node but tracks the mouse at the other end. Used for drawing new
      * edges.
      *
-     * @param node     the node to anchor to.
+     * @param node the node to anchor to.
      * @param mouseLoc the location of the mouse.
      * @return the new tracking edge (a display edge).
      */
@@ -232,7 +235,7 @@ public class GraphWorkbench extends AbstractWorkbench implements TripleClassifie
             case BIDIRECTED_EDGE:
                 return new DisplayEdge(node, mouseLoc, DisplayEdge.BIDIRECTED, color);
 
-            default :
+            default:
                 throw new IllegalStateException();
         }
     }
@@ -285,15 +288,15 @@ public class GraphWorkbench extends AbstractWorkbench implements TripleClassifie
     public void setEdgeMode(int edgeMode) {
         switch (edgeMode) {
             case DIRECTED_EDGE:
-                // Falls through!
+            // Falls through!
             case NONDIRECTED_EDGE:
-                // Falls through!
+            // Falls through!
             case PARTIALLY_ORIENTED_EDGE:
-                // Falls through!
+            // Falls through!
             case BIDIRECTED_EDGE:
                 this.edgeMode = edgeMode;
                 break;
-            default :
+            default:
                 throw new IllegalArgumentException();
         }
     }
@@ -304,10 +307,9 @@ public class GraphWorkbench extends AbstractWorkbench implements TripleClassifie
     public void setNodeType(int nodeType) {
         if (nodeType == MEASURED_NODE || nodeType == LATENT_NODE) {
             this.nodeType = nodeType;
-        }
-        else {
-            throw new IllegalArgumentException("The type of the node must be " +
-                    "MEASURED_NODE or LATENT_NODE.");
+        } else {
+            throw new IllegalArgumentException("The type of the node must be "
+                    + "MEASURED_NODE or LATENT_NODE.");
         }
     }
 
@@ -333,23 +335,21 @@ public class GraphWorkbench extends AbstractWorkbench implements TripleClassifie
             } else if (graphElement instanceof Edge) {
                 getWorkbench().getGraph().addEdge((Edge) graphElement);
             } else {
-                throw new IllegalArgumentException("The list of session " +
-                        "elements should contain only SessionNodeWrappers " +
-                        "and SessionEdges: " + graphElement);
+                throw new IllegalArgumentException("The list of session "
+                        + "elements should contain only SessionNodeWrappers "
+                        + "and SessionEdges: " + graphElement);
             }
         }
     }
 
     //===========================PRIVATE METHODS==========================//
-
     /**
      * Adjusts the name to avoid name conflicts in the new session and, if the
-     * name is adjusted, adjusts the position so the user can see the two
-     * nodes.
+     * name is adjusted, adjusts the position so the user can see the two nodes.
      *
      * @param node The node which is being adjusted
-     * @param deltaX  the shift in x
-     * @param deltaY  the shift in y.
+     * @param deltaX the shift in x
+     * @param deltaY the shift in y.
      */
     private void adjustNameAndPosition(Node node, int deltaX,
             int deltaY) {
@@ -373,22 +373,22 @@ public class GraphWorkbench extends AbstractWorkbench implements TripleClassifie
             throw new NullPointerException("Base name must be non-null.");
         }
         List<Node> currentNodes = this.getWorkbench().getGraph().getNodes();
-        if(!containsName(currentNodes, base)){
+        if (!containsName(currentNodes, base)) {
             return base;
         }
         // otherwise fine new unique name.
         base += "_";
         int i = 1;
-        while(containsName(currentNodes, base + i)){
+        while (containsName(currentNodes, base + i)) {
             i++;
         }
 
         return base + i;
     }
 
-    private static boolean containsName(List<Node> nodes, String name){
-        for(Node node : nodes){
-            if(name.equals(node.getName())){
+    private static boolean containsName(List<Node> nodes, String name) {
+        for (Node node : nodes) {
+            if (name.equals(node.getName())) {
                 return true;
             }
         }
@@ -396,7 +396,8 @@ public class GraphWorkbench extends AbstractWorkbench implements TripleClassifie
     }
 
     /**
-     * @return the names of the triple classifications. Coordinates with <code>getTriplesList</code>
+     * @return the names of the triple classifications. Coordinates with
+     * <code>getTriplesList</code>
      */
     public List<String> getTriplesClassificationTypes() {
         List<String> names = new ArrayList<>();
@@ -406,8 +407,8 @@ public class GraphWorkbench extends AbstractWorkbench implements TripleClassifie
     }
 
     /**
-     * @return the list of triples corresponding to <code>getTripleClassificationNames</code> for the given
-     * node.
+     * @return the list of triples corresponding to
+     * <code>getTripleClassificationNames</code> for the given node.
      */
     public List<List<Triple>> getTriplesLists(Node node) {
         List<List<Triple>> triplesList = new ArrayList<>();
@@ -421,8 +422,3 @@ public class GraphWorkbench extends AbstractWorkbench implements TripleClassifie
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 }
-
-
-
-
-


### PR DESCRIPTION
This fix address issue #1014.

Graph editor in Search box is not set to non-editable.  You may move the graph nodes around and change the layout of the graph.  However, you will not be able to delete any edges or nodes.  You will not be able to rename any node.

If you attach a Graph box to the Search box, you will be able to edit the graph as you wish.