### PR TITLE
fask.update

### DIFF
--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -19,7 +19,7 @@
 
     <div class="header">
         <h1>Tetrad Manual</h1>
-        <p>Last updated: March 27th, 2019</p>
+        <p>Last updated: April 16th, 2019</p>
     </div>
 
     <!-- Table of Contents, give each section a unique id -->

--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -3331,30 +3331,6 @@ Usually covariance values are chosen from U(-b, -a) U U(a, b) for some a, b; thi
             </td>
         </ul>
 
-        <h3 id="faskDelta" class="parameter_description">faskDelta</h3>
-        <ul class="parameter_description_list">
-            <li>Short Description: <span id="faskDelta_short_desc">Threshold for judging negative coefficient edges as X->Y (range (-1, 0))</span>
-            </li>
-            <li>Long Description: <span id="faskDelta_long_desc">For FASK, a dataset dependent threshold that affects accuracy for negatively skewed variables, in the range (-1, 0); the default value is -0.2. Sanchez-Romero, Ramsey et al., (2018) Network Neuroscience.</span>
-            </li>
-            <li>Default Value: <span id="faskDelta_default_value">-1.0</span></li>
-            <li>Lower Bound: <span id="faskDelta_lower_bound">-1.0</span></li>
-            <li>Upper Bound: <span id="faskDelta_upper_bound">1.0</span></li>
-            <li>Value Type: <span id="faskDelta_value_type">Double</span></li>
-        </ul>
-
-        <h3 id="faskDelta2" class="parameter_description">faskDelta2</h3>
-        <ul class="parameter_description_list">
-            <li>Short Description: <span id="faskDelta2_short_desc">Threshold for judging negative coefficient edges as X->Y</span>
-            </li>
-            <li>Long Description: <span id="faskDelta2_long_desc">For FASK, a dataset dependent threshold that affects accuracy for negatively skewed variables, in the range (-1, 0); the default value is -0.2. Sanchez-Romero, Ramsey et al., (2018) Network Neuroscience.</span>
-            </li>
-            <li>Default Value: <span id="faskDelta2_default_value">0.0</span></li>
-            <li>Lower Bound: <span id="faskDelta2_lower_bound">NaN</span></li>
-            <li>Upper Bound: <span id="faskDelta2_upper_bound">Infinity</span></li>
-            <li>Value Type: <span id="faskDelta2_value_type">Double</span></li>
-        </ul>
-
         <h3 id="fisherEpsilon" class="parameter_description">fisherEpsilon</h3>
         <ul class="parameter_description_list">
             <li>Short Description: <span id="fisherEpsilon_short_desc">Epsilon where |xi.t - xi.t-1| < epsilon, criterion for convergence</span>

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/model/GeneralAlgorithmRunner.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/model/GeneralAlgorithmRunner.java
@@ -322,7 +322,7 @@ public class GeneralAlgorithmRunner implements AlgorithmRunner, ParamsResettable
                     } else if (data.isMixed() && algDataType == DataType.Mixed) {
                         graphList.add(algo.search(data, parameters));
                     } else {
-                        throw new IllegalArgumentException("The algorithm was not expecting that type of data.");
+                            throw new IllegalArgumentException("The algorithm was not expecting that type of data.");
                     }
                 });
             }

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/model/GeneralAlgorithmRunner.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/model/GeneralAlgorithmRunner.java
@@ -322,7 +322,7 @@ public class GeneralAlgorithmRunner implements AlgorithmRunner, ParamsResettable
                     } else if (data.isMixed() && algDataType == DataType.Mixed) {
                         graphList.add(algo.search(data, parameters));
                     } else {
-                        throw new IllegalArgumentException("The type of data has changed; open up the search editor and run the algorithm again.");
+                        throw new IllegalArgumentException("The algorithm was not expecting that type of data.");
                     }
                 });
             }

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/multi/Fask.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/multi/Fask.java
@@ -11,6 +11,7 @@ import edu.cmu.tetrad.graph.Graph;
 import edu.cmu.tetrad.util.Parameters;
 import edu.pitt.dbmi.algo.resampling.GeneralResamplingTest;
 import edu.pitt.dbmi.algo.resampling.ResamplingEdgeEnsemble;
+
 import java.util.List;
 
 /**
@@ -53,12 +54,6 @@ public class Fask implements Algorithm, HasKnowledge, UsesScoreWrapper {
             search.setUseFasAdjacencies(parameters.getBoolean("useFasAdjacencies"));
             search.setUseSkewAdjacencies(parameters.getBoolean("useCorrDiffAdjacencies"));
             search.setAlpha(parameters.getDouble("twoCycleAlpha"));
-            search.setDelta(parameters.getDouble("faskDelta"));
-
-//            search.setPercentBootstrapForLinearityTest(parameters.getDouble("percentBootstrapForLinearityTest"));
-//            search.setNumBootstrapForLinearityTest(parameters.getInt("numBootstrapForLinearityTest"));
-//            search.setCutoffForLinearityTest(parameters.getDouble("cutoffForLinearityTest"));
-
             search.setKnowledge(knowledge);
             return getGraph(search);
         } else {
@@ -67,10 +62,10 @@ public class Fask implements Algorithm, HasKnowledge, UsesScoreWrapper {
             DataSet data = (DataSet) dataSet;
             GeneralResamplingTest search = new GeneralResamplingTest(data, fask, parameters.getInt("numberResampling"));
             search.setKnowledge(knowledge);
-            
+
             search.setPercentResampleSize(parameters.getDouble("percentResampleSize"));
             search.setResamplingWithReplacement(parameters.getBoolean("resamplingWithReplacement"));
-            
+
             ResamplingEdgeEnsemble edgeEnsemble = ResamplingEdgeEnsemble.Highest;
             switch (parameters.getInt("resamplingEnsemble", 1)) {
                 case 0:
@@ -103,7 +98,7 @@ public class Fask implements Algorithm, HasKnowledge, UsesScoreWrapper {
 
     @Override
     public DataType getDataType() {
-        return DataType.Mixed;
+        return DataType.Continuous;
     }
 
     @Override
@@ -112,11 +107,10 @@ public class Fask implements Algorithm, HasKnowledge, UsesScoreWrapper {
         parameters.add("depth");
         parameters.add("twoCycleAlpha");
         parameters.add("extraEdgeThreshold");
-        parameters.add("faskDelta");
 
         parameters.add("useFasAdjacencies");
         parameters.add("useCorrDiffAdjacencies");
-        
+
         // Resampling
         parameters.add("numberResampling");
         parameters.add("percentResampleSize");
@@ -142,7 +136,7 @@ public class Fask implements Algorithm, HasKnowledge, UsesScoreWrapper {
     public void setScoreWrapper(ScoreWrapper score) {
         this.score = score;
     }
-    
+
     @Override
     public ScoreWrapper getScoreWarpper() {
         return score;

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/multi/Fask.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/multi/Fask.java
@@ -1,13 +1,16 @@
 package edu.cmu.tetrad.algcomparison.algorithm.multi;
 
 import edu.cmu.tetrad.algcomparison.algorithm.Algorithm;
+import edu.cmu.tetrad.algcomparison.independence.IndependenceWrapper;
 import edu.cmu.tetrad.algcomparison.score.ScoreWrapper;
 import edu.cmu.tetrad.algcomparison.utils.HasKnowledge;
+import edu.cmu.tetrad.algcomparison.utils.TakesIndependenceWrapper;
 import edu.cmu.tetrad.algcomparison.utils.UsesScoreWrapper;
 import edu.cmu.tetrad.annotation.AlgType;
 import edu.cmu.tetrad.data.*;
 import edu.cmu.tetrad.graph.EdgeListGraph;
 import edu.cmu.tetrad.graph.Graph;
+import edu.cmu.tetrad.search.IndependenceTest;
 import edu.cmu.tetrad.util.Parameters;
 import edu.pitt.dbmi.algo.resampling.GeneralResamplingTest;
 import edu.pitt.dbmi.algo.resampling.ResamplingEdgeEnsemble;
@@ -27,17 +30,17 @@ import java.util.List;
         command = "fask",
         algoType = AlgType.forbid_latent_common_causes
 )
-public class Fask implements Algorithm, HasKnowledge, UsesScoreWrapper {
+public class Fask implements Algorithm, HasKnowledge, TakesIndependenceWrapper {
     static final long serialVersionUID = 23L;
-    private ScoreWrapper score;
+    private IndependenceWrapper test;
     private IKnowledge knowledge = new Knowledge2();
 
     public Fask() {
 
     }
 
-    public Fask(ScoreWrapper score) {
-        this.score = score;
+    public Fask(IndependenceWrapper test) {
+        this.test = test;
     }
 
     private Graph getGraph(edu.cmu.tetrad.search.Fask search) {
@@ -47,7 +50,7 @@ public class Fask implements Algorithm, HasKnowledge, UsesScoreWrapper {
     @Override
     public Graph search(DataModel dataSet, Parameters parameters) {
         if (parameters.getInt("numberResampling") < 1) {
-            edu.cmu.tetrad.search.Fask search = new edu.cmu.tetrad.search.Fask((DataSet) dataSet, score.getScore(dataSet, parameters));
+            edu.cmu.tetrad.search.Fask search = new edu.cmu.tetrad.search.Fask((DataSet) dataSet, test.getTest(dataSet, parameters));
             search.setDepth(parameters.getInt("depth"));
             search.setPenaltyDiscount(parameters.getDouble("penaltyDiscount"));
             search.setExtraEdgeThreshold(parameters.getDouble("extraEdgeThreshold"));
@@ -57,7 +60,7 @@ public class Fask implements Algorithm, HasKnowledge, UsesScoreWrapper {
             search.setKnowledge(knowledge);
             return getGraph(search);
         } else {
-            Fask fask = new Fask(score);
+            Fask fask = new Fask(test);
 
             DataSet data = (DataSet) dataSet;
             GeneralResamplingTest search = new GeneralResamplingTest(data, fask, parameters.getInt("numberResampling"));
@@ -79,7 +82,7 @@ public class Fask implements Algorithm, HasKnowledge, UsesScoreWrapper {
             }
             search.setEdgeEnsemble(edgeEnsemble);
             search.setAddOriginalDataset(parameters.getBoolean("addOriginalDataset"));
-            
+
             search.setParameters(parameters);
             search.setVerbose(parameters.getBoolean("verbose"));
             return search.search();
@@ -93,7 +96,7 @@ public class Fask implements Algorithm, HasKnowledge, UsesScoreWrapper {
 
     @Override
     public String getDescription() {
-        return "FASK using " + score.getDescription();
+        return "FASK using " + test.getDescription();
     }
 
     @Override
@@ -103,7 +106,7 @@ public class Fask implements Algorithm, HasKnowledge, UsesScoreWrapper {
 
     @Override
     public List<String> getParameters() {
-        List<String> parameters = score.getParameters();
+        List<String> parameters = test.getParameters();
         parameters.add("depth");
         parameters.add("twoCycleAlpha");
         parameters.add("extraEdgeThreshold");
@@ -132,13 +135,14 @@ public class Fask implements Algorithm, HasKnowledge, UsesScoreWrapper {
         this.knowledge = knowledge;
     }
 
+
     @Override
-    public void setScoreWrapper(ScoreWrapper score) {
-        this.score = score;
+    public void setIndependenceWrapper(IndependenceWrapper independenceWrapper) {
+        this.test = independenceWrapper;
     }
 
     @Override
-    public ScoreWrapper getScoreWarpper() {
-        return score;
+    public IndependenceWrapper getIndependenceWrapper() {
+        return test;
     }
 }

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/multi/Fask.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/multi/Fask.java
@@ -28,7 +28,8 @@ import java.util.List;
 @edu.cmu.tetrad.annotation.Algorithm(
         name = "FASK",
         command = "fask",
-        algoType = AlgType.forbid_latent_common_causes
+        algoType = AlgType.forbid_latent_common_causes,
+        dataType = DataType.Continuous
 )
 public class Fask implements Algorithm, HasKnowledge, TakesIndependenceWrapper {
     static final long serialVersionUID = 23L;

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/multi/FaskConcatenated.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/multi/FaskConcatenated.java
@@ -61,7 +61,6 @@ public class FaskConcatenated implements MultiDataSetAlgorithm, HasKnowledge, Us
             search.setDepth(parameters.getInt("depth"));
             search.setPenaltyDiscount(parameters.getDouble("penaltyDiscount"));
             search.setExtraEdgeThreshold(parameters.getDouble("extraEdgeThreshold"));
-            search.setDelta(parameters.getDouble("faskDelta"));
             search.setAlpha(parameters.getDouble("twoCycleAlpha"));
             search.setKnowledge(knowledge);
             
@@ -155,7 +154,6 @@ public class FaskConcatenated implements MultiDataSetAlgorithm, HasKnowledge, Us
         parameters.add("depth");
         parameters.add("twoCycleAlpha");
         parameters.add("extraEdgeThreshold");
-        parameters.add("faskDelta");
 
         parameters.add("numRuns");
         parameters.add("randomSelectionSize");

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/multi/FaskConcatenated.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/multi/FaskConcatenated.java
@@ -1,8 +1,11 @@
 package edu.cmu.tetrad.algcomparison.algorithm.multi;
 
 import edu.cmu.tetrad.algcomparison.algorithm.MultiDataSetAlgorithm;
+import edu.cmu.tetrad.algcomparison.independence.IndependenceWrapper;
 import edu.cmu.tetrad.algcomparison.score.ScoreWrapper;
 import edu.cmu.tetrad.algcomparison.utils.HasKnowledge;
+import edu.cmu.tetrad.algcomparison.utils.TakesIndependenceWrapper;
+import edu.cmu.tetrad.algcomparison.utils.TakesInitialGraph;
 import edu.cmu.tetrad.algcomparison.utils.UsesScoreWrapper;
 import edu.cmu.tetrad.data.*;
 import edu.cmu.tetrad.graph.EdgeListGraph;
@@ -30,18 +33,18 @@ import java.util.List;
 //        command = "fask-concatenated",
 //        algoType = AlgType.forbid_latent_common_causes
 //)
-public class FaskConcatenated implements MultiDataSetAlgorithm, HasKnowledge, UsesScoreWrapper {
+public class FaskConcatenated implements MultiDataSetAlgorithm, HasKnowledge, TakesIndependenceWrapper {
 
     static final long serialVersionUID = 23L;
-    private ScoreWrapper score;
+    private IndependenceWrapper test;
     private IKnowledge knowledge = new Knowledge2();
 
     public FaskConcatenated() {
 
     }
 
-    public FaskConcatenated(ScoreWrapper score) {
-        this.score = score;
+    public FaskConcatenated(IndependenceWrapper test) {
+        this.test = test;
     }
 
     @Override
@@ -57,7 +60,7 @@ public class FaskConcatenated implements MultiDataSetAlgorithm, HasKnowledge, Us
 
             dataSet.setNumberFormat(new DecimalFormat("0.000000000000000000"));
 
-            Fask search = new Fask(dataSet, score.getScore(dataSet, parameters));
+            Fask search = new Fask(dataSet, test.getTest(dataSet, parameters));
             search.setDepth(parameters.getInt("depth"));
             search.setPenaltyDiscount(parameters.getDouble("penaltyDiscount"));
             search.setExtraEdgeThreshold(parameters.getDouble("extraEdgeThreshold"));
@@ -66,7 +69,7 @@ public class FaskConcatenated implements MultiDataSetAlgorithm, HasKnowledge, Us
             
             return search.search();
         } else {
-            FaskConcatenated algorithm = new FaskConcatenated(score);
+            FaskConcatenated algorithm = new FaskConcatenated(test);
 
             List<DataSet> datasets = new ArrayList<>();
 
@@ -104,7 +107,7 @@ public class FaskConcatenated implements MultiDataSetAlgorithm, HasKnowledge, Us
         if (parameters.getInt("numberResampling") < 1) {
             return search(Collections.singletonList((DataModel) DataUtils.getContinuousDataSet(dataSet)), parameters);
         } else {
-            FaskConcatenated algorithm = new FaskConcatenated(score);
+            FaskConcatenated algorithm = new FaskConcatenated(test);
 
             List<DataSet> dataSets = Collections.singletonList(DataUtils.getContinuousDataSet(dataSet));
             GeneralResamplingTest search = new GeneralResamplingTest(dataSets, algorithm, parameters.getInt("numberResampling"));
@@ -150,7 +153,7 @@ public class FaskConcatenated implements MultiDataSetAlgorithm, HasKnowledge, Us
 
     @Override
     public List<String> getParameters() {
-        List<String> parameters = score.getParameters();
+        List<String> parameters = test.getParameters();
         parameters.add("depth");
         parameters.add("twoCycleAlpha");
         parameters.add("extraEdgeThreshold");
@@ -180,12 +183,12 @@ public class FaskConcatenated implements MultiDataSetAlgorithm, HasKnowledge, Us
     }
 
     @Override
-    public void setScoreWrapper(ScoreWrapper score) {
-        this.score = score;
+    public void setIndependenceWrapper(IndependenceWrapper independenceWrapper) {
+        this.test = independenceWrapper;
     }
-    
+
     @Override
-    public ScoreWrapper getScoreWarpper() {
-        return score;
+    public IndependenceWrapper getIndependenceWrapper() {
+        return test;
     }
 }

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/multi/MultiFask.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/multi/MultiFask.java
@@ -29,7 +29,8 @@ import java.util.List;
 @edu.cmu.tetrad.annotation.Algorithm(
         name = "MultiFask",
         command = "multi-fask",
-        algoType = AlgType.forbid_latent_common_causes
+        algoType = AlgType.forbid_latent_common_causes,
+        dataType = DataType.Continuous
 )
 public class MultiFask implements MultiDataSetAlgorithm, HasKnowledge {
 

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/score/SemBicScore.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/score/SemBicScore.java
@@ -1,8 +1,6 @@
 package edu.cmu.tetrad.algcomparison.score;
 
-import edu.cmu.tetrad.data.DataModel;
-import edu.cmu.tetrad.data.DataType;
-import edu.cmu.tetrad.data.DataUtils;
+import edu.cmu.tetrad.data.*;
 import edu.cmu.tetrad.graph.Node;
 import edu.cmu.tetrad.search.Score;
 import edu.cmu.tetrad.util.Parameters;
@@ -29,7 +27,7 @@ public class SemBicScore implements ScoreWrapper {
     public Score getScore(DataModel dataSet, Parameters parameters) {
         this.dataSet = dataSet;
         edu.cmu.tetrad.search.SemBicScore semBicScore
-                = new edu.cmu.tetrad.search.SemBicScore(DataUtils.getCovMatrix(dataSet));
+                = new edu.cmu.tetrad.search.SemBicScore(new CovarianceMatrixOnTheFly((DataSet) dataSet));
         double penaltyDiscount = parameters.getDouble("penaltyDiscount");
         this.penaltyDiscount = penaltyDiscount;
         semBicScore.setPenaltyDiscount(penaltyDiscount);

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/score/SemBicScore.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/score/SemBicScore.java
@@ -4,6 +4,7 @@ import edu.cmu.tetrad.data.*;
 import edu.cmu.tetrad.graph.Node;
 import edu.cmu.tetrad.search.Score;
 import edu.cmu.tetrad.util.Parameters;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -26,8 +27,12 @@ public class SemBicScore implements ScoreWrapper {
     @Override
     public Score getScore(DataModel dataSet, Parameters parameters) {
         this.dataSet = dataSet;
+
+        ICovarianceMatrix cov = dataSet instanceof ICovarianceMatrix ? (ICovarianceMatrix) dataSet
+                : new CovarianceMatrixOnTheFly((DataSet) dataSet);
+
         edu.cmu.tetrad.search.SemBicScore semBicScore
-                = new edu.cmu.tetrad.search.SemBicScore(new CovarianceMatrixOnTheFly((DataSet) dataSet));
+                = new edu.cmu.tetrad.search.SemBicScore(cov);
         double penaltyDiscount = parameters.getDouble("penaltyDiscount");
         this.penaltyDiscount = penaltyDiscount;
         semBicScore.setPenaltyDiscount(penaltyDiscount);

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/simulation/LinearFisherModel.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/simulation/LinearFisherModel.java
@@ -39,7 +39,7 @@ public class LinearFisherModel implements Simulation, TakesData {
         if (shocks != null) {
             JOptionPane.showMessageDialog(JOptionUtils.centeringComp(),
                     "The initial dataset you've provided will be used as initial shocks"
-                    + "\nfor a Fisher model.");
+                            + "\nfor a Fisher model.");
 
             for (DataModel _shocks : shocks) {
                 if (_shocks == null) {

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/Fask.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/Fask.java
@@ -45,7 +45,7 @@ import static java.lang.Math.*;
 public final class Fask implements GraphSearch {
 
     // The score to be used for the FAS adjacency search.
-    private final Score score;
+    private final IndependenceTest test;
 
     // An initial graph to orient, skipping the adjacency step.
     private Graph initialGraph = null;
@@ -87,9 +87,9 @@ public final class Fask implements GraphSearch {
     /**
      * @param dataSet These datasets must all have the same variables, in the same order.
      */
-    public Fask(DataSet dataSet, Score score) {
+    public Fask(DataSet dataSet, IndependenceTest test) {
         this.dataSet = dataSet;
-        this.score = score;
+        this.test = test;
 
         data = dataSet.getDoubleData().transpose().toArray();
     }
@@ -130,7 +130,6 @@ public final class Fask implements GraphSearch {
 
             G0 = g1;
         } else {
-            IndependenceTest test = new IndTestScore(score, dataSet);
             System.out.println("FAS");
 
             FasStable fas = new FasStable(test);
@@ -354,7 +353,7 @@ public final class Fask implements GraphSearch {
 
         final double a = correlation(x, y);
 
-        if (a < 0 && sk_ey > 0) {
+        if (a < 0) {// && sk_ey > 0) {
             lr *= -1;
         }
 

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/Fask.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/Fask.java
@@ -88,6 +88,10 @@ public final class Fask implements GraphSearch {
      * @param dataSet These datasets must all have the same variables, in the same order.
      */
     public Fask(DataSet dataSet, IndependenceTest test) {
+        if (!dataSet.isContinuous()) {
+            throw new IllegalArgumentException("For FASK, the dataset must be entirely continuous");
+        }
+
         this.dataSet = dataSet;
         this.test = test;
 

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/IndTestPositiveCorr.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/IndTestPositiveCorr.java
@@ -21,11 +21,9 @@
 
 package edu.cmu.tetrad.search;
 
-import edu.cmu.tetrad.data.ColtDataSet;
 import edu.cmu.tetrad.data.CovarianceMatrixOnTheFly;
 import edu.cmu.tetrad.data.DataSet;
 import edu.cmu.tetrad.data.ICovarianceMatrix;
-import edu.cmu.tetrad.graph.GraphUtils;
 import edu.cmu.tetrad.graph.Node;
 import edu.cmu.tetrad.util.NumberFormatUtil;
 import edu.cmu.tetrad.util.StatUtils;
@@ -167,9 +165,9 @@ public final class IndTestPositiveCorr implements IndependenceTest {
         double pc1 = partialCorrelation(x, y, _Z, x, 0, +1);
         double pc2 = partialCorrelation(x, y, _Z, y, 0, +1);
 
-        int nc = StatUtils.getRows(x, x, Double.NEGATIVE_INFINITY, +1).size();
-        int nc1 = StatUtils.getRows(x, x, 0, +1).size();
-        int nc2 = StatUtils.getRows(y, y, 0, +1).size();
+        int nc = StatUtils.getRows(x, Double.NEGATIVE_INFINITY, +1).size();
+        int nc1 = StatUtils.getRows(x, 0, +1).size();
+        int nc2 = StatUtils.getRows(y, 0, +1).size();
 
         double z = 0.5 * (log(1.0 + pc) - log(1.0 - pc));
         double z1 = 0.5 *  (log(1.0 + pc1) - log(1.0 - pc1));

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/MultiFask.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/MultiFask.java
@@ -142,7 +142,7 @@ public class MultiFask {
                 }
 
                 if ((isUseFasAdjacencies() && G0.isAdjacentTo(X, Y)) || (isUseSkewAdjacencies() && (Math.abs(c1 - c2) / dataSets.size()) > getExtraEdgeThreshold())) {
-                    // if ((isUseFasAdjacencies() && G0.isAdjacentTo(X, Y)) || (isUseSkewAdjacencies() && (Math.abs(c1 - c2) > getExtraEdgeThreshold()))) {
+                    // if ((isUseFasAdjacencies() && G0.isAdjacentTo(X, Y)) || (isUseSkewAdjacencies() && (Math.abs(c1 - c2) > getSkewEdgeAlpha()))) {
 
                     if (knowledgeOrients(X, Y)) {
                         graph.addDirectedEdge(X, Y);
@@ -265,9 +265,9 @@ public class MultiFask {
                     double pc1 = partialCorrelation(x[i], y[i], _Z[i], x[i], 0, +1);
                     double pc2 = partialCorrelation(x[i], y[i], _Z[i], y[i], 0, +1);
 
-                    int nc = StatUtils.getRows(x[i], x[i], Double.NEGATIVE_INFINITY, +1).size();
-                    int nc1 = StatUtils.getRows(x[i], x[i], 0, +1).size();
-                    int nc2 = StatUtils.getRows(y[i], y[i], 0, +1).size();
+                    int nc = StatUtils.getRows(x[i], Double.NEGATIVE_INFINITY, +1).size();
+                    int nc1 = StatUtils.getRows(x[i], 0, +1).size();
+                    int nc2 = StatUtils.getRows(y[i], 0, +1).size();
 
                     double z = 0.5 * (log(1.0 + pc) - log(1.0 - pc));
                     double z1 = 0.5 * (log(1.0 + pc1) - log(1.0 - pc1));
@@ -297,9 +297,9 @@ public class MultiFask {
                     double pc1 = partialCorrelation(x[i], y[i], _emptyZ, x[i], 0, +1);
                     double pc2 = partialCorrelation(x[i], y[i], _emptyZ, y[i], 0, +1);
 
-                    int nc = StatUtils.getRows(x[i], x[i], Double.NEGATIVE_INFINITY, +1).size();
-                    int nc1 = StatUtils.getRows(x[i], x[i], 0, +1).size();
-                    int nc2 = StatUtils.getRows(y[i], y[i], 0, +1).size();
+                    int nc = StatUtils.getRows(x[i], Double.NEGATIVE_INFINITY, +1).size();
+                    int nc1 = StatUtils.getRows(x[i], 0, +1).size();
+                    int nc2 = StatUtils.getRows(y[i], 0, +1).size();
 
                     double z = 0.5 * (log(1.0 + pc) - log(1.0 - pc));
                     double z1 = 0.5 * (log(1.0 + pc1) - log(1.0 - pc1));

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/SemBicScore.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/SemBicScore.java
@@ -89,7 +89,7 @@ public class SemBicScore implements Score {
      */
     public double localScore(int i, int... parents) {
         for (int p : parents) if (forbidden.contains(p)) return Double.NaN;
-    
+
         try {
             double s2 = getCovariances().getValue(i, i);
             int p = parents.length;

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/SemBicScore.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/SemBicScore.java
@@ -89,7 +89,7 @@ public class SemBicScore implements Score {
      */
     public double localScore(int i, int... parents) {
         for (int p : parents) if (forbidden.contains(p)) return Double.NaN;
-
+    
         try {
             double s2 = getCovariances().getValue(i, i);
             int p = parents.length;
@@ -107,7 +107,7 @@ public class SemBicScore implements Score {
             }
 
             int n = getSampleSize();
-            return -(n) * log(s2) - getPenaltyDiscount() * log(n);
+            return -(n) * log(s2) - getPenaltyDiscount() * p * log(n);
             // + getStructurePrior(parents.length);// - getStructurePrior(parents.length + 1);
         } catch (Exception e) {
             boolean removedOne = true;
@@ -157,8 +157,8 @@ public class SemBicScore implements Score {
         int p = 2 + z.length;
 
         int N = covariances.getSampleSize();
-        return -N * Math.log(1.0 - r * r) - p * getPenaltyDiscount() * Math.log(N);
-//        return localScore(y, append(z, x)) - localScore(y, z);
+//        return -N * Math.log(1.0 - r * r) - p * getPenaltyDiscount() * Math.log(N) + sp1 - sp2;
+        return localScore(y, append(z, x)) - localScore(y, z);
     }
 
     private List<Node> getVariableList(int[] indices) {

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/util/StatUtils.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/util/StatUtils.java
@@ -23,12 +23,8 @@ package edu.cmu.tetrad.util;
 
 import cern.colt.list.DoubleArrayList;
 import cern.jet.stat.Descriptive;
-import edu.cmu.tetrad.data.BoxDataSet;
-import edu.cmu.tetrad.data.CovarianceMatrix;
-import edu.cmu.tetrad.data.DoubleDataBox;
 import org.apache.commons.math3.distribution.ChiSquaredDistribution;
 import org.apache.commons.math3.distribution.NormalDistribution;
-import org.apache.commons.math3.linear.SingularMatrixException;
 
 import java.util.*;
 
@@ -1235,15 +1231,14 @@ public final class StatUtils {
             thirdMoment += s * s * s;
         }
 
-        double ess = secondMoment / N;
-        double esss = thirdMoment / (N - 1);
+        double ess = secondMoment / (N - 1);
+        double esss = thirdMoment / (N);
 
         if (secondMoment == 0) {
             throw new ArithmeticException("StatUtils.skew:  There is no skew " +
                     "when the variance is zero.");
         }
 
-        //        thirdMoment /= (N * Math.pow(secondMoment, 1.5));
         return esss / Math.pow(ess, 1.5);
     }
 
@@ -1592,7 +1587,7 @@ public final class StatUtils {
         }
 
         if (!pSorted) {
-            pValues = new ArrayList<>(pValues);
+//            pValues = new ArrayList<>(pValues);
             Collections.sort(pValues);
         }
 
@@ -1769,7 +1764,7 @@ public final class StatUtils {
 //        return cov / Math.sqrt(var1 * var2);
 
         TetradMatrix inverse = submatrix.inverse();
-        return -(1.0 * inverse.get(0, 1)) / Math.sqrt(inverse.get(0, 0) * inverse.get(1, 1));
+        return (-inverse.get(0, 1)) / Math.sqrt(inverse.get(0, 0) * inverse.get(1, 1));
     }
 
     /**

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/util/StatUtils.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/util/StatUtils.java
@@ -2053,7 +2053,7 @@ public final class StatUtils {
     }
 
     public static double[][] covMatrix(double[] x, double[] y, double[][] z, double[] condition, double threshold, double direction) {
-        List<Integer> rows = getRows(x, condition, threshold, direction);
+        List<Integer> rows = getRows(condition, threshold, direction);
 
         double[][] allData = new double[z.length + 2][];
 
@@ -2077,29 +2077,36 @@ public final class StatUtils {
         double[][] cov = new double[z.length + 2][z.length + 2];
 
         for (int i = 0; i < z.length + 2; i++) {
-            for (int j = 0; j < z.length + 2; j++) {
+            for (int j = i; j < z.length + 2; j++) {
+//                double c = StatUtils.sxy(subdata[i], subdata[j]);
                 double c = StatUtils.covariance(subdata[i], subdata[j]);
                 cov[i][j] = c;
+                cov[j][i] = c;
             }
         }
 
         return cov;
     }
 
-    public static List<Integer> getRows(double[] x, double[] condition, double threshold, double direction) {
+    public static List<Integer> getRows(double[] x, double threshold, double direction) {
         List<Integer> rows = new ArrayList<>();
 
         for (int k = 0; k < x.length; k++) {
             if (direction > threshold) {
-                if (condition[k] > threshold) {
+                if (x[k] > threshold) {
                     rows.add(k);
                 }
             } else if (direction < threshold) {
-                if (condition[k] > threshold) {
+                if (x[k] > threshold) {
+                    rows.add(k);
+                }
+            } else {
+                if (x[k] > threshold) {
                     rows.add(k);
                 }
             }
         }
+
         return rows;
     }
 

--- a/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestFges.java
+++ b/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestFges.java
@@ -590,13 +590,16 @@ public class TestFges {
         String trueString = "Graph Nodes:\n" +
                 "ABILITY;GPQ;PREPROD;QFJ;SEX;CITES;PUBS\n" +
                 "\n" +
-                "Graph Edges: \n" +
-                "1. ABILITY --> GPQ \n" +
-                "2. ABILITY --> PREPROD \n" +
-                "3. GPQ --> QFJ \n" +
-                "4. PUBS --> CITES \n" +
-                "5. QFJ --> PUBS \n" +
-                "6. SEX --> PUBS";
+                "Graph Edges:\n" +
+                "1. ABILITY --> GPQ\n" +
+                "2. ABILITY --> PREPROD\n" +
+                "3. ABILITY --> PUBS\n" +
+                "4. GPQ --> QFJ\n" +
+                "5. PREPROD --> CITES\n" +
+                "6. PUBS --> CITES\n" +
+                "7. QFJ --> CITES\n" +
+                "8. QFJ --> PUBS\n" +
+                "9. SEX --> PUBS";
 
 
 

--- a/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestSimulatedFmri.java
+++ b/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestSimulatedFmri.java
@@ -57,7 +57,6 @@ public class TestSimulatedFmri {
         parameters.set("penaltyDiscount", 4);
         parameters.set("depth", -1);
         parameters.set("twoCycleAlpha", 1e-10);
-        parameters.set("faskDelta", -.2);
         parameters.set("reverseOrientationsBySignOfCorrelation", false);
         parameters.set("reverseOrientationsBySkewnessOfVariables", false);
 
@@ -213,7 +212,6 @@ public class TestSimulatedFmri {
         parameters.set("penaltyDiscount", 1);
         parameters.set("depth", -1);
         parameters.set("twoCycleAlpha", 0);
-        parameters.set("faskDelta", -.1);
 
         parameters.set("numRuns", 10);
         parameters.set("randomSelectionSize", 2);

--- a/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestSimulatedFmri.java
+++ b/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestSimulatedFmri.java
@@ -24,6 +24,8 @@ package edu.cmu.tetrad.test;
 import edu.cmu.tetrad.algcomparison.Comparison;
 import edu.cmu.tetrad.algcomparison.algorithm.Algorithms;
 import edu.cmu.tetrad.algcomparison.algorithm.multi.*;
+import edu.cmu.tetrad.algcomparison.independence.FisherZ;
+import edu.cmu.tetrad.algcomparison.independence.IndependenceWrapper;
 import edu.cmu.tetrad.algcomparison.score.SemBicScore;
 import edu.cmu.tetrad.algcomparison.simulation.Simulations;
 import edu.cmu.tetrad.algcomparison.statistic.*;
@@ -34,6 +36,7 @@ import edu.cmu.tetrad.graph.EdgeListGraph;
 import edu.cmu.tetrad.graph.Graph;
 import edu.cmu.tetrad.graph.Node;
 import edu.cmu.tetrad.search.Fask;
+import edu.cmu.tetrad.search.IndTestFisherZ;
 import edu.cmu.tetrad.search.Lofs2;
 import edu.cmu.tetrad.sem.GeneralizedSemIm;
 import edu.cmu.tetrad.sem.GeneralizedSemPm;
@@ -177,7 +180,7 @@ public class TestSimulatedFmri {
 
         Algorithms algorithms = new Algorithms();
 
-        algorithms.add(new FaskConcatenated(new SemBicScore()));
+        algorithms.add(new FaskConcatenated(new FisherZ()));
 //        algorithms.add(new FaskGfciConcatenated(new SemBicTest()));
 
 //        algorithms.add(new FasLofsConcatenated(Lofs2.Rule.RSkew));
@@ -256,7 +259,8 @@ public class TestSimulatedFmri {
 //        algorithms.add(new LofsConcatenated(Lofs2.Rule.SkewE));
 //        algorithms.add(new LofsConcatenated(Lofs2.Rule.Patel));
 
-        algorithms.add(new FaskConcatenated( new SemBicScore()));
+        algorithms.add(new FaskConcatenated(new FisherZ() {
+        }));
 //        algorithms.add(new FasLofsConcatenated(Lofs2.Rule.R1));
 //        algorithms.add(new FasLofsConcatenated(Lofs2.Rule.R3));
 //        algorithms.add(new FasLofsConcatenated(Lofs2.Rule.RSkew));
@@ -336,7 +340,7 @@ public class TestSimulatedFmri {
 //
 //        algorithms.add(new FgesConcatenated(new edu.cmu.tetrad.algcomparison.score.SemBicScore(), true));
 //        algorithms.add(new PcStableMaxConcatenated(new SemBicTest(), true));
-        algorithms.add(new FaskConcatenated(new SemBicScore()));
+        algorithms.add(new FaskConcatenated(new FisherZ()));
 //        algorithms.add(new FasLofsConcatenated(Lofs2.Rule.R1));
 //        algorithms.add(new FasLofsConcatenated(Lofs2.Rule.R2));
 //        algorithms.add(new FasLofsConcatenated(Lofs2.Rule.R3));
@@ -398,10 +402,8 @@ public class TestSimulatedFmri {
                 GeneralizedSemIm im = new GeneralizedSemIm(pm);
                 DataSet data = im.simulateData(N, false);
 
-                edu.cmu.tetrad.search.SemBicScore score = new edu.cmu.tetrad.search.SemBicScore(new CovarianceMatrixOnTheFly(data, false));
-                score.setPenaltyDiscount(penaltyDiscount);
 
-                Fask fask = new Fask(data, score);
+                Fask fask = new Fask(data, new IndTestFisherZ(data, 0.001));
                 fask.setPenaltyDiscount(penaltyDiscount);
                 fask.setAlpha(alpha);
                 Graph out = fask.search();
@@ -441,10 +443,7 @@ public class TestSimulatedFmri {
                 GeneralizedSemIm im = new GeneralizedSemIm(pm);
                 DataSet data = im.simulateData(N, false);
 
-                edu.cmu.tetrad.search.SemBicScore score = new edu.cmu.tetrad.search.SemBicScore(new CovarianceMatrixOnTheFly(data, false));
-                score.setPenaltyDiscount(penaltyDiscount);
-
-                Fask fask = new Fask(data, score);
+                Fask fask = new Fask(data, new IndTestFisherZ(data, 0.001));
                 fask.setPenaltyDiscount(penaltyDiscount);
                 fask.setAlpha(alpha);
                 Graph out = fask.search();
@@ -491,9 +490,7 @@ public class TestSimulatedFmri {
         GeneralizedSemIm im = new GeneralizedSemIm(pm);
         DataSet data = im.simulateData(1000, false);
 
-        edu.cmu.tetrad.search.SemBicScore score = new edu.cmu.tetrad.search.SemBicScore(new CovarianceMatrixOnTheFly(data, false));
-
-        Fask fask = new Fask(data, score);
+        Fask fask = new Fask(data, new IndTestFisherZ(data, 0.001));
         fask.setPenaltyDiscount(1);
         fask.setAlpha(0.5);
         Graph out = fask.search();

--- a/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestSimulatedFmri2.java
+++ b/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestSimulatedFmri2.java
@@ -40,7 +40,6 @@ public class TestSimulatedFmri2 {
         Parameters parameters = new Parameters();
         parameters.set("penaltyDiscount", 8);
         parameters.set("depth", -1);
-        parameters.set("faskDelta", -0.2);
         parameters.set("twoCycleAlpha", 1e-15);
 
         parameters.set("numRuns", 60);

--- a/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestSimulatedFmri2.java
+++ b/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestSimulatedFmri2.java
@@ -23,6 +23,7 @@ package edu.cmu.tetrad.test;
 
 import edu.cmu.tetrad.algcomparison.Comparison;
 import edu.cmu.tetrad.algcomparison.algorithm.Algorithms;
+import edu.cmu.tetrad.algcomparison.independence.FisherZ;
 import edu.cmu.tetrad.algcomparison.score.SemBicScore;
 import edu.cmu.tetrad.algcomparison.simulation.Simulations;
 import edu.cmu.tetrad.algcomparison.statistic.*;
@@ -114,7 +115,7 @@ public class TestSimulatedFmri2 {
 
         Algorithms algorithms = new Algorithms();
 
-        algorithms.add(new edu.cmu.tetrad.algcomparison.algorithm.multi.Fask(new SemBicScore()));
+        algorithms.add(new edu.cmu.tetrad.algcomparison.algorithm.multi.Fask(new FisherZ()));
 //
         Comparison comparison = new Comparison();
 


### PR DESCRIPTION
Makes some improvements to FASK. Several files needed to be adjusted. In terms of the interface, the 'delta' parameter was removed (it is now unnecessary) and the SEM BIC score was changed to a Fisher Z test. Tests were swapped for scores in all related files. The calculations for skewness and partial correlation were corrected.

To reproduce, follow the below instructions. Make a simulation-search-compare pipeline. In simulation, select linear fisher and select the option for non-Gaussian errors. Select enough variables to give it a run for its money, say 50. In search, select FASK. Fisher Z should be showing. In the parameters, probably using alpha = 0.001 is best, since the default sample size is 1000. run. then double click Compare. Adjacency and arrowhead precision and recall should all be high. In this example, they are all 1.0.

The manual will need to be adjusted for the above. I guess I can do that.

This uses the Minnesota rule.

<img width="317" alt="Screen Shot 2019-04-16 at 11 28 43 AM" src="https://user-images.githubusercontent.com/9853255/56223330-890a4780-603b-11e9-91ea-a58e273f70b6.png">
<img width="780" alt="Screen Shot 2019-04-16 at 11 29 00 AM" src="https://user-images.githubusercontent.com/9853255/56223331-890a4780-603b-11e9-9152-29caa2730cd2.png">
<img width="790" alt="Screen Shot 2019-04-16 at 11 29 10 AM" src="https://user-images.githubusercontent.com/9853255/56223332-890a4780-603b-11e9-973f-7362bcd775e4.png">
<img width="786" alt="Screen Shot 2019-04-16 at 11 29 25 AM" src="https://user-images.githubusercontent.com/9853255/56223334-890a4780-603b-11e9-8242-7d1439422ef2.png">
<img width="753" alt="Screen Shot 2019-04-16 at 11 29 41 AM" src="https://user-images.githubusercontent.com/9853255/56223335-890a4780-603b-11e9-8ee9-f2c7a7461bd9.png">

@cg09 @yuanzhou @mglymour