### PR TITLE
Unicode edge prob table

### DIFF
--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/EdgeTypeTable.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/EdgeTypeTable.java
@@ -65,12 +65,12 @@ public class EdgeTypeTable extends JPanel {
         "Node 2",
         "Ensemble",
         "No edge",
-        "-->",
-        "<--",
-        "-->", // -G> pd nl
-        "<--", // <G- pd nl
-        "-->", // =G> dd nl
-        "<--", // <G= dd nl
+        "\u2192",
+        "\u2190",
+        "\u2192", // -G> pd nl
+        "\u2190", // <G- pd nl
+        "\u2192", // =G> dd nl
+        "\u2190", // <G= dd nl
         "o->",
         "<-o",
         "o-o",


### PR DESCRIPTION
This is a change to rendering of arrows in the edge prob table from ASCII to unicode so that the arrows don't look like they are dashed.