### PR TITLE
Fix violations of Sonar rule 2184

### DIFF
--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/EbicScore.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/EbicScore.java
@@ -20,13 +20,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 package edu.cmu.tetrad.search;
-import DataSet;
-import CovarianceMatrix;
-import ICovarianceMatrix;
-import SemBicScore;
-import Score;
-import CorrelationMatrix;
-import DataUtils;
 
 import edu.cmu.tetrad.data.*;
 import edu.cmu.tetrad.graph.Node;

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/EbicScore.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/EbicScore.java
@@ -20,6 +20,13 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 package edu.cmu.tetrad.search;
+import DataSet;
+import CovarianceMatrix;
+import ICovarianceMatrix;
+import SemBicScore;
+import Score;
+import CorrelationMatrix;
+import DataUtils;
 
 import edu.cmu.tetrad.data.*;
 import edu.cmu.tetrad.graph.Node;
@@ -127,7 +134,7 @@ public class EbicScore implements Score {
     }
 
     public static double getP(int pn, int m0, double lambda) {
-        return 2 - pow((1 + (exp(-(lambda - 1) / 2.)) * sqrt(lambda)), pn - m0);
+        return 2 - pow(1 + (exp(-(lambda - 1) / 2.)) * sqrt(lambda), (double) pn - m0);
     }
 
     /**


### PR DESCRIPTION
Hi,

This PR fixes 1 violations of [Sonar Rule 2184: 'Math operands should be cast before assignment'](https://rules.sonarsource.com/java/RSPEC-2184). This is done without introducing any new violations of Sonar rules.

The patch was generated automatically with the tool [Sorald](https://github.com/SpoonLabs/sorald). For details on the fix applied here, please see [Sorald's documentation on rule 2184](https://github.com/SpoonLabs/sorald/blob/master/docs/HANDLED_RULES.md#math-operands-should-be-cast-before-assignment-sonar-rule-2184).

P.S.: Note that this PR is not created/submitted by a bot. If you have any feedback, please leave them as comments.