### PR TITLE
Disabling remote job execution to allow Tetrad GUI to launch properly.

### DIFF
--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/app/TetradDesktop.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/app/TetradDesktop.java
@@ -115,8 +115,8 @@ public final class TetradDesktop extends JPanel implements DesktopControllable,
         desktopPane.setBorder(new BevelBorder(BevelBorder.LOWERED));
         desktopPane.addPropertyChangeListener(this);
 
-        ///////////////////////////// DISABLING REMOTE JOB MANAGER ////////////////////////////
-        ///////////// THIS WAS PREVENTING THE TETRAD FROM LUNCHING PROPERLY ///////////////////
+        /* DISABLING REMOTE JOB MANAGER */
+        /* THIS WAS PREVENTING THE TETRAD FROM LUNCHING PROPERLY */
 
         // HPC account manager
         final org.hibernate.Session session;

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/app/TetradDesktop.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/app/TetradDesktop.java
@@ -115,6 +115,9 @@ public final class TetradDesktop extends JPanel implements DesktopControllable,
         desktopPane.setBorder(new BevelBorder(BevelBorder.LOWERED));
         desktopPane.addPropertyChangeListener(this);
 
+        ///////////////////////////// DISABLING REMOTE JOB MANAGER ////////////////////////////
+        ///////////// THIS WAS PREVENTING THE TETRAD FROM LUNCHING PROPERLY ///////////////////
+
         // HPC account manager
         final org.hibernate.Session session;
         try {
@@ -127,7 +130,8 @@ public final class TetradDesktop extends JPanel implements DesktopControllable,
             this.hpcJobManager = new HpcJobManager(session, processors);
 
         } catch (ExceptionInInitializerError e) {
-            e.printStackTrace();
+//            e.printStackTrace();
+            TetradLogger.getInstance().forceLogMessage("Disabling remote job manager.");
         }
 
         this.setupDesktop();

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/GeneralAlgorithmEditor.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/GeneralAlgorithmEditor.java
@@ -428,6 +428,9 @@ public class GeneralAlgorithmEditor extends JPanel implements PropertyChangeList
                 algorithmParamRequest.setJvmOptions(jvmOptions);
             }
 
+            ///////////////////////////// DISABLING REMOTE JOB MANAGER ////////////////////////////
+            ///////////// THIS WAS PREVENTING THE TETRAD FROM LUNCHING PROPERLY ///////////////////
+
             // Hpc parameters
             final HpcAccountManager hpcAccountManager = desktop.getHpcAccountManager();
             JsonWebToken jsonWebToken = HpcAccountUtils.getJsonWebToken(hpcAccountManager, hpcAccount);
@@ -464,6 +467,9 @@ public class GeneralAlgorithmEditor extends JPanel implements PropertyChangeList
             progressTextArea.append("Preparing...");
             progressTextArea.updateUI();
 
+            ///////////////////////////// DISABLING REMOTE JOB MANAGER ////////////////////////////
+            ///////////// THIS WAS PREVENTING THE TETRAD FROM LUNCHING PROPERLY ///////////////////
+
             HpcJobManager hpcJobManager = desktop.getHpcJobManager();
 
             // 4.1 Save HpcJobInfo
@@ -494,9 +500,18 @@ public class GeneralAlgorithmEditor extends JPanel implements PropertyChangeList
     }
 
     private HpcAccount showRemoteComputingOptions(String algoId) {
-        List<HpcAccount> hpcAccounts = desktop.getHpcAccountManager().getHpcAccounts();
+        List<HpcAccount> hpcAccounts = null;
 
-        if (hpcAccounts == null || hpcAccounts.isEmpty()) {
+        ///////////////////////////// DISABLING REMOTE JOB MANAGER ////////////////////////////
+        ///////////// THIS WAS PREVENTING THE TETRAD FROM LUNCHING PROPERLY ///////////////////
+
+        try {
+            hpcAccounts = desktop.getHpcAccountManager().getHpcAccounts();
+
+            if (hpcAccounts == null || hpcAccounts.isEmpty()) {
+                return null;
+            }
+        } catch (Exception e) {
             return null;
         }
 

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/GeneralAlgorithmEditor.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/GeneralAlgorithmEditor.java
@@ -428,8 +428,8 @@ public class GeneralAlgorithmEditor extends JPanel implements PropertyChangeList
                 algorithmParamRequest.setJvmOptions(jvmOptions);
             }
 
-            ///////////////////////////// DISABLING REMOTE JOB MANAGER ////////////////////////////
-            ///////////// THIS WAS PREVENTING THE TETRAD FROM LUNCHING PROPERLY ///////////////////
+            /* DISABLING REMOTE JOB MANAGER */
+            /* THIS WAS PREVENTING THE TETRAD FROM LUNCHING PROPERLY */
 
             // Hpc parameters
             final HpcAccountManager hpcAccountManager = desktop.getHpcAccountManager();
@@ -467,8 +467,8 @@ public class GeneralAlgorithmEditor extends JPanel implements PropertyChangeList
             progressTextArea.append("Preparing...");
             progressTextArea.updateUI();
 
-            ///////////////////////////// DISABLING REMOTE JOB MANAGER ////////////////////////////
-            ///////////// THIS WAS PREVENTING THE TETRAD FROM LUNCHING PROPERLY ///////////////////
+            /* DISABLING REMOTE JOB MANAGER */
+            /* THIS WAS PREVENTING THE TETRAD FROM LUNCHING PROPERLY */
 
             HpcJobManager hpcJobManager = desktop.getHpcJobManager();
 
@@ -502,8 +502,8 @@ public class GeneralAlgorithmEditor extends JPanel implements PropertyChangeList
     private HpcAccount showRemoteComputingOptions(String algoId) {
         List<HpcAccount> hpcAccounts = null;
 
-        ///////////////////////////// DISABLING REMOTE JOB MANAGER ////////////////////////////
-        ///////////// THIS WAS PREVENTING THE TETRAD FROM LUNCHING PROPERLY ///////////////////
+        /* DISABLING REMOTE JOB MANAGER */
+        /* THIS WAS PREVENTING THE TETRAD FROM LUNCHING PROPERLY */
 
         try {
             hpcAccounts = desktop.getHpcAccountManager().getHpcAccounts();


### PR DESCRIPTION
This can easily be reversed.