### PR TITLE
Added a parameter for lambda for the Poisson Prior Score

### DIFF
--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -7817,6 +7817,25 @@ tabs will not appear.</p> -->
         </ul>
 
         <h3 class="parameter_description"
+            id="poissonLambda">poissonLambda</h3>
+        <ul
+                class="parameter_description_list">
+            <li>Short Description: <span
+                    id="poissonLambda_short_desc">Lambda parameter for the Poisson distribution
+        (> 0)</span></li>
+            <li>Long Description: <span
+                    id="poissonLambda_long_desc"> Lambda parameter for the Poisson distribution</span></li>
+            <li>Default Value: <span
+                    id="poissonLambda_default_value">1</span></li>
+            <li>Lower
+                Bound: <span id="poissonLambda_lower_bound">1e-10</span></li>
+            <li>Upper Bound: <span
+                    id="poissonLambda_upper_bound">Infinity</span></li>
+            <li>Value
+                Type: <span id="poissonLambda_value_type">Double</span></li>
+        </ul>
+
+        <h3 class="parameter_description"
             id="skipNumRecords">skipNumRecords</h3>
         <ul
                 class="parameter_description_list">

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/score/PoissonPriorScore.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/score/PoissonPriorScore.java
@@ -45,7 +45,7 @@ public class PoissonPriorScore implements ScoreWrapper {
             throw new IllegalArgumentException("Expecting either a dataset or a covariance matrix.");
         }
 
-        score.setStructurePrior(parameters.getDouble(Params.SEM_BIC_STRUCTURE_PRIOR));
+        score.setLambda(parameters.getDouble(Params.POISSON_LAMBDA));
 
         return score;
     }
@@ -64,7 +64,7 @@ public class PoissonPriorScore implements ScoreWrapper {
     public List<String> getParameters() {
         List<String> parameters = new ArrayList<>();
         parameters.add(Params.PRECOMPUTE_COVARIANCES);
-        parameters.add(Params.SEM_BIC_STRUCTURE_PRIOR);
+        parameters.add(Params.POISSON_LAMBDA);
         return parameters;
     }
 

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/PoissonPriorScore.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/PoissonPriorScore.java
@@ -61,7 +61,7 @@ public class PoissonPriorScore implements Score {
     // True if row subsets should be calculated.
     private boolean calculateRowSubsets;
 
-    private double structurePrior = 3.;
+    private double lambda = 3.;
 
     /**
      * Constructs the score using a covariance matrix.
@@ -138,7 +138,7 @@ public class PoissonPriorScore implements Score {
             return Double.NaN;
         }
 
-        double r = structurePrior == 0 ? 0.0 : k * log(structurePrior);
+        double r = k * log(lambda);
 
         // Bryan
         double score = - 0.5 * this.N * log(varRy) - 0.5 * k * log(this.N) + r - Gamma.logGamma(k + 1.);
@@ -258,9 +258,9 @@ public class PoissonPriorScore implements Score {
         return _z;
     }
 
-    public void setStructurePrior(double structurePrior) {
-        if (structurePrior < 1.0) throw new IllegalArgumentException("Structure prior can't be < 1: " + structurePrior);
-        this.structurePrior = structurePrior;
+    public void setLambda(double lambda) {
+        if (lambda < 1.0) throw new IllegalArgumentException("Structure prior can't be < 1: " + lambda);
+        this.lambda = lambda;
     }
 }
 

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/util/Params.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/util/Params.java
@@ -194,6 +194,7 @@ public final class Params {
     public static final String SEM_BIC_RULE = "semBicRule";
     public static final String SEM_GIC_RULE = "semGicRule";
     public static final String SEM_BIC_STRUCTURE_PRIOR = "semBicStructurePrior";
+    public static final String POISSON_LAMBDA = "poissonLambda";
     public static final String NUM_STARTS = "numStarts";
     public static final String CACHE_SCORES = "cacheScores";
     public static final String OTHER_PERM_METHOD = "otherPermMethod";

--- a/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestAnneAnalysis3.java
+++ b/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestAnneAnalysis3.java
@@ -94,7 +94,7 @@ public class TestAnneAnalysis3 {
 //                        edu.cmu.tetrad.search.SemBicScore score = new edu.cmu.tetrad.search.SemBicScore(cov);
                         edu.cmu.tetrad.search.PoissonPriorScore score = new edu.cmu.tetrad.search.PoissonPriorScore(cov);
 //                        score.setPenaltyDiscount(penalty);
-                        score.setStructurePrior(vars.size() / 2.);
+                        score.setLambda(vars.size() / 2.);
 
 //                        Grasp alg = new Grasp(score);
                         Boss alg = new Boss(score);


### PR DESCRIPTION
If you run a linear, Gaussian search and select the Poisson Prior Score, there should be a lambda parameter with default 1. The range should be any number > 0.