### PR TITLE
Fixing some instability in RFCI

### DIFF
--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/model/FciRunner.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/model/FciRunner.java
@@ -111,7 +111,6 @@ public class FciRunner extends AbstractAlgorithmRunner
         if (getParams().getBoolean("rfciUsed", false)) {
             Rfci fci = new Rfci(getIndependenceTest());
             fci.setKnowledge(knowledge);
-            fci.setCompleteRuleSetUsed(getParams().getBoolean("completeRuleSetUsed", false));
             fci.setMaxPathLength(getParams().getInt("maxReachablePathLength", -1));
             fci.setDepth(getParams().getInt("depth", -1));
             graph = fci.search();

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/pag/PagSamplingRfci.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/pag/PagSamplingRfci.java
@@ -60,7 +60,6 @@ public class PagSamplingRfci implements Algorithm, HasKnowledge {
         pagSamplingRfci.setKnowledge(this.knowledge);
         pagSamplingRfci.setDepth(parameters.getInt(Params.DEPTH));
         pagSamplingRfci.setMaxPathLength(parameters.getInt(Params.MAX_PATH_LENGTH));
-        pagSamplingRfci.setCompleteRuleSetUsed(parameters.getBoolean(Params.COMPLETE_RULE_SET_USED));
         pagSamplingRfci.setNumRandomizedSearchModels(parameters.getInt(Params.NUM_RANDOMIZED_SEARCH_MODELS));
 
         // ProbabilisticTest parameters

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/pag/Rfci.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/pag/Rfci.java
@@ -63,7 +63,6 @@ public class Rfci implements Algorithm, HasKnowledge, TakesIndependenceWrapper {
             search.setKnowledge(this.knowledge);
             search.setDepth(parameters.getInt(Params.DEPTH));
             search.setMaxPathLength(parameters.getInt(Params.MAX_PATH_LENGTH));
-            search.setCompleteRuleSetUsed(parameters.getBoolean(Params.COMPLETE_RULE_SET_USED));
             search.setVerbose(parameters.getBoolean(Params.VERBOSE));
             return search.search();
         } else {
@@ -98,7 +97,6 @@ public class Rfci implements Algorithm, HasKnowledge, TakesIndependenceWrapper {
 
         parameters.add(Params.DEPTH);
         parameters.add(Params.MAX_PATH_LENGTH);
-        parameters.add(Params.COMPLETE_RULE_SET_USED);
         parameters.add(Params.TIME_LAG);
 
         parameters.add(Params.VERBOSE);

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/pag/RfciBsc.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/pag/RfciBsc.java
@@ -54,7 +54,6 @@ public class RfciBsc implements Algorithm, HasKnowledge {
         search.setKnowledge(this.knowledge);
         search.setDepth(parameters.getInt(Params.DEPTH));
         search.setMaxPathLength(parameters.getInt(Params.MAX_PATH_LENGTH));
-        search.setCompleteRuleSetUsed(parameters.getBoolean(Params.COMPLETE_RULE_SET_USED));
         search.setVerbose(parameters.getBoolean(Params.VERBOSE));
 
         edu.pitt.dbmi.algo.bayesian.constraint.search.RfciBsc RfciBsc = new edu.pitt.dbmi.algo.bayesian.constraint.search.RfciBsc(search);

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/calibration/DataForCalibration_RFCI.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/calibration/DataForCalibration_RFCI.java
@@ -358,7 +358,6 @@ public class DataForCalibration_RFCI {
 
         Rfci fci = new Rfci(test);
         fci.setVerbose(false);
-        fci.setCompleteRuleSetUsed(true);
         fci.setDepth(depth);
 
         Graph estPag = fci.search();

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/CcdMax.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/CcdMax.java
@@ -201,6 +201,7 @@ public final class CcdMax implements GraphSearch {
         long start =  MillisecondTimes.timeMillis();
 
         FasConcurrent fas = new FasConcurrent(this.independenceTest);
+        fas.setStable(true);
         fas.setDepth(getDepth());
         fas.setKnowledge(this.knowledge);
         fas.setVerbose(false);

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/CpcStable.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/CpcStable.java
@@ -195,6 +195,7 @@ public final class CpcStable implements GraphSearch {
 
 
         FasConcurrent fas = new FasConcurrent(getIndependenceTest());
+        fas.setStable(true);
         fas.setOut(this.out);
         return search(fas, nodes);
     }

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/RBExperiments.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/RBExperiments.java
@@ -690,7 +690,6 @@ public class RBExperiments {
         Rfci BSCrfci = new Rfci(BSCtest);
 
         BSCrfci.setVerbose(false);
-        BSCrfci.setCompleteRuleSetUsed(false);
         BSCrfci.setDepth(this.depth);
 
         for (int i = 0; i < numModels; i++) {
@@ -708,7 +707,6 @@ public class RBExperiments {
         Rfci fci1 = new Rfci(test);
         fci1.setDepth(this.depth);
         fci1.setVerbose(false);
-        fci1.setCompleteRuleSetUsed(false);
         Graph PAG_CS = fci1.search();
         PAG_CS = GraphUtils.replaceNodes(PAG_CS, data.getVariables());
         return PAG_CS;

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/Rfci.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/Rfci.java
@@ -196,10 +196,15 @@ public final class Rfci implements GraphSearch {
         long stop1 = MillisecondTimes.timeMillis();
         long start2 = MillisecondTimes.timeMillis();
 
+        FciOrient orient = new FciOrient(new SepsetsSet(this.sepsets, this.independenceTest));
+
+        // For RFCI always executes R5-10
+        orient.setCompleteRuleSetUsed(true);
+
         // The original FCI, with or without JiJi Zhang's orientation rules
-        fciOrientbk(getKnowledge(), this.graph, this.variables);
+        orient.fciOrientbk(getKnowledge(), this.graph, this.variables);
         ruleR0_RFCI(getRTuples());  // RFCI Algorithm 4.4
-        doFinalOrientation();
+        orient.doFinalOrientation(this.graph);
 
         long endTime = MillisecondTimes.timeMillis();
         this.elapsedTime = endTime - beginTime;
@@ -467,108 +472,110 @@ public final class Rfci implements GraphSearch {
         }
     }
 
-    //////////////////////////////////////////////////
-    // Orients the graph according to rules for RFCI
-    //////////////////////////////////////////////////
-    private void doFinalOrientation() {
+//    //////////////////////////////////////////////////
+//    // Orients the graph according to rules for RFCI
+//    //////////////////////////////////////////////////
+//    private void doFinalOrientation() {
+//        FciOrient orient = new FciOrient(new SepsetsSet(this.sepsets, this.independenceTest));
+//
+//        // For RFCI always executes R5-10
+//        orient.setCompleteRuleSetUsed(true);
+//        orient.doFinalOrientation(this.graph);
+//
+////        // This loop handles Zhang's rules R1-R3 (same as in the original FCI)
+////        this.changeFlag = true;
+////
+////        while (this.changeFlag) {
+////            this.changeFlag = false;
+////            orient.setChangeFlag(false);
+////            orient.rulesR1R2cycle(this.graph);
+////            orient.ruleR3(this.graph);
+////            this.changeFlag = orient.isChangeFlag();
+////            orient.ruleR4B(this.graph);   // some changes to the original R4 inline
+////        }
+////
+////        // For RFCI always executes R5-10
+////
+////        // Now, by a remark on page 100 of Zhang's dissertation, we apply rule
+////        // R5 once.
+////        orient.ruleR5(this.graph);
+////
+////        // Now, by a further remark on page 102, we apply R6,R7 as many times
+////        // as possible.
+////        this.changeFlag = true;
+////
+////        while (this.changeFlag) {
+////            this.changeFlag = false;
+////            orient.setChangeFlag(false);
+////            orient.ruleR6R7(this.graph);
+////            this.changeFlag = orient.isChangeFlag();
+////        }
+////
+////        // Finally, we apply R8-R10 as many times as possible.
+////        this.changeFlag = true;
+////
+////        while (this.changeFlag) {
+////            this.changeFlag = false;
+////            orient.setChangeFlag(false);
+////            orient.rulesR8R9R10(this.graph);
+////            this.changeFlag = orient.isChangeFlag();
+////        }
+//    }
 
-
-        FciOrient orient = new FciOrient(new SepsetsSet(this.sepsets, this.independenceTest));
-
-        // This loop handles Zhang's rules R1-R3 (same as in the original FCI)
-        this.changeFlag = true;
-
-        while (this.changeFlag) {
-            this.changeFlag = false;
-            orient.setChangeFlag(false);
-            orient.rulesR1R2cycle(this.graph);
-            orient.ruleR3(this.graph);
-            this.changeFlag = orient.isChangeFlag();
-            orient.ruleR4B(this.graph);   // some changes to the original R4 inline
-        }
-
-        // For RFCI always executes R5-10
-
-        // Now, by a remark on page 100 of Zhang's dissertation, we apply rule
-        // R5 once.
-        orient.ruleR5(this.graph);
-
-        // Now, by a further remark on page 102, we apply R6,R7 as many times
-        // as possible.
-        this.changeFlag = true;
-
-        while (this.changeFlag) {
-            this.changeFlag = false;
-            orient.setChangeFlag(false);
-            orient.ruleR6R7(this.graph);
-            this.changeFlag = orient.isChangeFlag();
-        }
-
-        // Finally, we apply R8-R10 as many times as possible.
-        this.changeFlag = true;
-
-        while (this.changeFlag) {
-            this.changeFlag = false;
-            orient.setChangeFlag(false);
-            orient.rulesR8R9R10(this.graph);
-            this.changeFlag = orient.isChangeFlag();
-        }
-    }
-
-    /**
-     * Orients according to background knowledge
-     */
-    private void fciOrientbk(Knowledge bk, Graph graph, List<Node> variables) {
-        this.logger.log("info", "Starting BK Orientation.");
-
-        for (Iterator<KnowledgeEdge> it =
-             bk.forbiddenEdgesIterator(); it.hasNext(); ) {
-            KnowledgeEdge edge = it.next();
-
-            //match strings to variables in the graph.
-            Node from = SearchGraphUtils.translate(edge.getFrom(), variables);
-            Node to = SearchGraphUtils.translate(edge.getTo(), variables);
-
-
-            if (from == null || to == null) {
-                continue;
-            }
-
-            if (graph.getEdge(from, to) == null) {
-                continue;
-            }
-
-            // Orient to*-&gt;from
-            graph.setEndpoint(to, from, Endpoint.ARROW);
-            graph.setEndpoint(from, to, Endpoint.CIRCLE);
-            this.changeFlag = true;
-            this.logger.log("knowledgeOrientation", SearchLogUtils.edgeOrientedMsg("Knowledge", graph.getEdge(from, to)));
-        }
-
-        for (Iterator<KnowledgeEdge> it =
-             bk.requiredEdgesIterator(); it.hasNext(); ) {
-            KnowledgeEdge edge = it.next();
-
-            //match strings to variables in this graph
-            Node from = SearchGraphUtils.translate(edge.getFrom(), variables);
-            Node to = SearchGraphUtils.translate(edge.getTo(), variables);
-
-            if (from == null || to == null) {
-                continue;
-            }
-
-            if (graph.getEdge(from, to) == null) {
-                continue;
-            }
-
-            graph.setEndpoint(to, from, Endpoint.TAIL);
-            graph.setEndpoint(from, to, Endpoint.ARROW);
-            this.changeFlag = true;
-            this.logger.log("knowledgeOrientation", SearchLogUtils.edgeOrientedMsg("Knowledge", graph.getEdge(from, to)));
-        }
-
-        this.logger.log("info", "Finishing BK Orientation.");
-    }
+//    /**
+//     * Orients according to background knowledge
+//     */
+//    private void fciOrientbk(Knowledge bk, Graph graph, List<Node> variables) {
+//        this.logger.log("info", "Starting BK Orientation.");
+//
+//        for (Iterator<KnowledgeEdge> it =
+//             bk.forbiddenEdgesIterator(); it.hasNext(); ) {
+//            KnowledgeEdge edge = it.next();
+//
+//            //match strings to variables in the graph.
+//            Node from = SearchGraphUtils.translate(edge.getFrom(), variables);
+//            Node to = SearchGraphUtils.translate(edge.getTo(), variables);
+//
+//
+//            if (from == null || to == null) {
+//                continue;
+//            }
+//
+//            if (graph.getEdge(from, to) == null) {
+//                continue;
+//            }
+//
+//            // Orient to*-&gt;from
+//            graph.setEndpoint(to, from, Endpoint.ARROW);
+//            graph.setEndpoint(from, to, Endpoint.CIRCLE);
+//            this.changeFlag = true;
+//            this.logger.log("knowledgeOrientation", SearchLogUtils.edgeOrientedMsg("Knowledge", graph.getEdge(from, to)));
+//        }
+//
+//        for (Iterator<KnowledgeEdge> it =
+//             bk.requiredEdgesIterator(); it.hasNext(); ) {
+//            KnowledgeEdge edge = it.next();
+//
+//            //match strings to variables in this graph
+//            Node from = SearchGraphUtils.translate(edge.getFrom(), variables);
+//            Node to = SearchGraphUtils.translate(edge.getTo(), variables);
+//
+//            if (from == null || to == null) {
+//                continue;
+//            }
+//
+//            if (graph.getEdge(from, to) == null) {
+//                continue;
+//            }
+//
+//            graph.setEndpoint(to, from, Endpoint.TAIL);
+//            graph.setEndpoint(from, to, Endpoint.ARROW);
+//            this.changeFlag = true;
+//            this.logger.log("knowledgeOrientation", SearchLogUtils.edgeOrientedMsg("Knowledge", graph.getEdge(from, to)));
+//        }
+//
+//        this.logger.log("info", "Finishing BK Orientation.");
+//    }
 
 
     /**
@@ -579,23 +586,25 @@ public final class Rfci implements GraphSearch {
      * @return Whether the arrowpoint is allowed.
      */
     private boolean isArrowpointAllowed(Node x, Node y) {
-        if (this.graph.getEndpoint(x, y) == Endpoint.ARROW) {
-            return true;
-        }
+        return FciOrient.isArrowpointAllowed(x, y, this.graph, this.knowledge);
 
-        if (this.graph.getEndpoint(x, y) == Endpoint.TAIL) {
-            return false;
-        }
-
-        if (this.graph.getEndpoint(y, x) == Endpoint.ARROW) {
-            if (!this.knowledge.isForbidden(x.getName(), y.getName())) return true;
-        }
-
-        if (this.graph.getEndpoint(y, x) == Endpoint.TAIL) {
-            if (!this.knowledge.isForbidden(x.getName(), y.getName())) return true;
-        }
-
-        return this.graph.getEndpoint(y, x) == Endpoint.CIRCLE;
+//        if (this.graph.getEndpoint(x, y) == Endpoint.ARROW) {
+//            return true;
+//        }
+//
+//        if (this.graph.getEndpoint(x, y) == Endpoint.TAIL) {
+//            return false;
+//        }
+//
+//        if (this.graph.getEndpoint(y, x) == Endpoint.ARROW) {
+//            if (!this.knowledge.isForbidden(x.getName(), y.getName())) return true;
+//        }
+//
+//        if (this.graph.getEndpoint(y, x) == Endpoint.TAIL) {
+//            if (!this.knowledge.isForbidden(x.getName(), y.getName())) return true;
+//        }
+//
+//        return this.graph.getEndpoint(y, x) == Endpoint.CIRCLE;
     }
 
     /**

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/Rfci.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/Rfci.java
@@ -69,11 +69,6 @@ public final class Rfci implements GraphSearch {
     private final IndependenceTest independenceTest;
 
     /**
-     * flag for complete rule set, true if should use complete rule set, false otherwise.
-     */
-    private boolean completeRuleSetUsed = true;
-
-    /**
      * The maximum length for any discriminating path. -1 if unlimited; otherwise, a positive integer.
      */
     private int maxPathLength = -1;
@@ -221,22 +216,6 @@ public final class Rfci implements GraphSearch {
 
     public void setKnowledge(Knowledge knowledge) {
         this.knowledge = new Knowledge((Knowledge) knowledge);
-    }
-
-    /**
-     * @return true if Zhang's complete rule set should be used, false if only R1-R4 (the rule set of the original FCI)
-     * should be used. False by default.
-     */
-    public boolean isCompleteRuleSetUsed() {
-        return this.completeRuleSetUsed;
-    }
-
-    /**
-     * @param completeRuleSetUsed set to true if Zhang's complete rule set should be used, false if only R1-R4 (the rule
-     *                            set of the original FCI) should be used. False by default.
-     */
-    public void setCompleteRuleSetUsed(boolean completeRuleSetUsed) {
-        this.completeRuleSetUsed = completeRuleSetUsed;
     }
 
     //===========================PRIVATE METHODS=========================//

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/Rfci.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/Rfci.java
@@ -22,7 +22,6 @@
 package edu.cmu.tetrad.search;
 
 import edu.cmu.tetrad.data.Knowledge;
-import edu.cmu.tetrad.data.KnowledgeEdge;
 import edu.cmu.tetrad.graph.*;
 import edu.cmu.tetrad.util.ChoiceGenerator;
 import edu.cmu.tetrad.util.MillisecondTimes;
@@ -68,11 +67,6 @@ public final class Rfci implements GraphSearch {
     private final List<Node> variables = new ArrayList<>();
 
     private final IndependenceTest independenceTest;
-
-    /**
-     * change flag for repeat rules
-     */
-    private boolean changeFlag = true;
 
     /**
      * flag for complete rule set, true if should use complete rule set, false otherwise.
@@ -130,7 +124,7 @@ public final class Rfci implements GraphSearch {
         this.independenceTest = independenceTest;
         this.variables.addAll(independenceTest.getVariables());
 
-        Set<Node> remVars = new HashSet<>();
+        List<Node> remVars = new ArrayList<>();
         for (Node node1 : this.variables) {
             boolean search = false;
             for (Node node2 : searchVars) {
@@ -169,7 +163,7 @@ public final class Rfci implements GraphSearch {
     }
 
     public Graph search(List<Node> nodes) {
-        return search(new FasConcurrent(getIndependenceTest()), nodes);
+        return search(new Fas(getIndependenceTest()), nodes);
     }
 
     public Graph search(IFas fas, List<Node> nodes) {
@@ -188,7 +182,6 @@ public final class Rfci implements GraphSearch {
         fas.setKnowledge(getKnowledge());
         fas.setDepth(this.depth);
         fas.setVerbose(this.verbose);
-//        fas.setFci(true);
         this.graph = fas.search();
         this.graph.reorientAllWith(Endpoint.CIRCLE);
         this.sepsets = fas.getSepsets();
@@ -387,11 +380,11 @@ public final class Rfci implements GraphSearch {
             if (!sepset.contains(j)
                     && this.graph.isAdjacentTo(i, j) && this.graph.isAdjacentTo(j, k)) {
 
-                if (!isArrowpointAllowed(i, j)) {
+                if (!FciOrient.isArrowpointAllowed(i, j, this.graph, this.knowledge)) {
                     continue;
                 }
 
-                if (!isArrowpointAllowed(k, j)) {
+                if (!FciOrient.isArrowpointAllowed(k, j, this.graph, this.knowledge)) {
                     continue;
                 }
 
@@ -428,7 +421,6 @@ public final class Rfci implements GraphSearch {
                     Node[] newTuple = {i, j, k};
                     rTuples.add(newTuple);
                 }
-
             }
         }
 
@@ -577,35 +569,6 @@ public final class Rfci implements GraphSearch {
 //        this.logger.log("info", "Finishing BK Orientation.");
 //    }
 
-
-    /**
-     * Helper method. Appears to check if an arrowpoint is permitted by background knowledge.
-     *
-     * @param x The possible other node.
-     * @param y The possible point node.
-     * @return Whether the arrowpoint is allowed.
-     */
-    private boolean isArrowpointAllowed(Node x, Node y) {
-        return FciOrient.isArrowpointAllowed(x, y, this.graph, this.knowledge);
-
-//        if (this.graph.getEndpoint(x, y) == Endpoint.ARROW) {
-//            return true;
-//        }
-//
-//        if (this.graph.getEndpoint(x, y) == Endpoint.TAIL) {
-//            return false;
-//        }
-//
-//        if (this.graph.getEndpoint(y, x) == Endpoint.ARROW) {
-//            if (!this.knowledge.isForbidden(x.getName(), y.getName())) return true;
-//        }
-//
-//        if (this.graph.getEndpoint(y, x) == Endpoint.TAIL) {
-//            if (!this.knowledge.isForbidden(x.getName(), y.getName())) return true;
-//        }
-//
-//        return this.graph.getEndpoint(y, x) == Endpoint.CIRCLE;
-    }
 
     /**
      * @return the maximum length of any discriminating path, or -1 of unlimited.

--- a/tetrad-lib/src/main/java/edu/pitt/dbmi/algo/bayesian/constraint/search/PagSamplingRfci.java
+++ b/tetrad-lib/src/main/java/edu/pitt/dbmi/algo/bayesian/constraint/search/PagSamplingRfci.java
@@ -24,8 +24,6 @@ public class PagSamplingRfci implements GraphSearch {
     // Rfci parameters
     private int depth = -1;
     private int maxPathLength = -1;
-    private boolean completeRuleSetUsed = true;
-
     // IndTestProbabilistic parameters
     private boolean threshold;
     private double cutoff = 0.5;
@@ -95,10 +93,6 @@ public class PagSamplingRfci implements GraphSearch {
     /**
      * Call shutdown to reject incoming tasks, and then calling shutdownNow, if
      * necessary, to cancel any lingering tasks.
-     *
-     * @param pool
-     * @see
-     * https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/ExecutorService.html
      */
     private void shutdownAndAwaitTermination(ExecutorService pool) {
         pool.shutdown();
@@ -137,14 +131,6 @@ public class PagSamplingRfci implements GraphSearch {
 
     public void setMaxPathLength(int maxPathLength) {
         this.maxPathLength = maxPathLength;
-    }
-
-    public boolean isCompleteRuleSetUsed() {
-        return completeRuleSetUsed;
-    }
-
-    public void setCompleteRuleSetUsed(boolean completeRuleSetUsed) {
-        this.completeRuleSetUsed = completeRuleSetUsed;
     }
 
     public int getNumRandomizedSearchModels() {
@@ -203,7 +189,6 @@ public class PagSamplingRfci implements GraphSearch {
                 Rfci rfci = new Rfci(independenceTest);
                 rfci.setDepth(depth);
                 rfci.setMaxPathLength(maxPathLength);
-                rfci.setCompleteRuleSetUsed(completeRuleSetUsed);
                 rfci.setVerbose(verbose);
 
                 return rfci.search();

--- a/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestRfciBsc.java
+++ b/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestRfciBsc.java
@@ -68,7 +68,6 @@ public class TestRfciBsc {
         IndTestProbabilistic test = new IndTestProbabilistic(dataSet);
         edu.cmu.tetrad.search.Rfci rfci = new edu.cmu.tetrad.search.Rfci(test);
         rfci.setVerbose(true);
-        rfci.setCompleteRuleSetUsed(false);
         rfci.setDepth(depth);
 
         edu.pitt.dbmi.algo.bayesian.constraint.search.RfciBsc rfciBsc = new edu.pitt.dbmi.algo.bayesian.constraint.search.RfciBsc(rfci);
@@ -142,7 +141,6 @@ public class TestRfciBsc {
         IndTestProbabilistic test = new IndTestProbabilistic(dataSet);
         edu.cmu.tetrad.search.Rfci rfci = new edu.cmu.tetrad.search.Rfci(test);
         rfci.setVerbose(true);
-        rfci.setCompleteRuleSetUsed(false);
         rfci.setDepth(depth);
 
         edu.pitt.dbmi.algo.bayesian.constraint.search.RfciBsc rfciBsc = new edu.pitt.dbmi.algo.bayesian.constraint.search.RfciBsc(rfci);


### PR DESCRIPTION
The instability was due to the use of FasDeterministic; swapped out FAS instead.

Also, cleaned up the code to use the most recent version of FciOrient. Also, removed the completete ruleset parameter, since RFCI always needs to use the complete ruleset, so this is not a parameter.