### PR TITLE
Setting 'verbose' default to 'false'.

### DIFF
--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -8503,7 +8503,7 @@ tabs will not appear.</p> -->
                     id="verbose_long_desc"> If this parameter is set to ‘Yes’, extra
         (“verbose”) output will be printed if available giving some details
         about the step-by-step operation of the algorithm.</span></li>
-            <li>Default Value: <span id="verbose_default_value">true</span></li>
+            <li>Default Value: <span id="verbose_default_value">false</span></li>
             <li>Lower Bound: <span id="verbose_lower_bound"></span></li>
             <li>Upper Bound: <span id="verbose_upper_bound"></span></li>
             <li>Value Type: <span id="verbose_value_type">Boolean</span></li>


### PR DESCRIPTION
Should be false anyway but for bootstrapping this is critical.