### PR TITLE
Fixing the too-verbose bootstrap output problem.

### DIFF
--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/MarkovCheckEditor.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/MarkovCheckEditor.java
@@ -619,7 +619,7 @@ public class MarkovCheckEditor extends JPanel {
                             Node y = fact.getY();
                             List<Node> z = fact.getZ();
                             boolean verbose = test.isVerbose();
-                            test.setVerbose(true);
+                            test.setVerbose(verbose);
                             IndependenceResult result = test.checkIndependence(x, y, z);
                             boolean indep = result.independent();
                             double pValue = result.getPValue();

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/LvSwap.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/LvSwap.java
@@ -524,7 +524,7 @@ public final class LvSwap implements GraphSearch {
         fciOrient.setDoDiscriminatingPathTailRule(doDiscriminatingPathTailRule);
         fciOrient.setMaxPathLength(this.maxPathLength);
         fciOrient.setKnowledge(knowledge2);
-        fciOrient.setVerbose(true);
+        fciOrient.setVerbose(verbose);
         fciOrient.doFinalOrientation(G);
     }
 

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/PcAll.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/PcAll.java
@@ -370,7 +370,7 @@ public final class PcAll implements GraphSearch {
 
         MeekRules meekRules = new MeekRules();
         meekRules.setKnowledge(this.knowledge);
-        meekRules.setVerbose(true);
+        meekRules.setVerbose(verbose);
         meekRules.orientImplied(this.graph);
 
         long endTime = MillisecondTimes.timeMillis();

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/SpFci.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/SpFci.java
@@ -162,7 +162,7 @@ public final class SpFci implements GraphSearch {
         fciOrient.setMaxPathLength(this.maxPathLength);
         fciOrient.setDoDiscriminatingPathColliderRule(this.doDiscriminatingPathRule);
         fciOrient.setDoDiscriminatingPathTailRule(this.doDiscriminatingPathRule);
-        fciOrient.setVerbose(true);
+        fciOrient.setVerbose(verbose);
         fciOrient.setKnowledge(knowledge2);
 
         fciOrient.doFinalOrientation(graph);

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/simulation/HsimRepeatAC.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/simulation/HsimRepeatAC.java
@@ -80,7 +80,7 @@ public class HsimRepeatAC {
             }
             //pass verbose on to the lower level as well
             if (this.verbose) {
-                study.setVerbose(true);
+                study.setVerbose(verbose);
             }
 
             //run the edu.cmu.tetrad.study! yay!

--- a/tetrad-lib/src/main/java/edu/pitt/dbmi/algo/resampling/GeneralResamplingTest.java
+++ b/tetrad-lib/src/main/java/edu/pitt/dbmi/algo/resampling/GeneralResamplingTest.java
@@ -106,7 +106,7 @@ public class GeneralResamplingTest {
     }
 
     private static void countAdjConfMatrix(int[][] adjAr, List<Edge> edges, Graph truth, Graph estimate, int start,
-            int end) {
+                                           int end) {
         if (start == end) {
             Edge edge = edges.get(start);
             Node n1 = truth.getNode(edge.getNode1().toString());
@@ -141,7 +141,7 @@ public class GeneralResamplingTest {
     }
 
     private static void countEdgeTypeConfMatrix(int[][] edgeAr, List<Edge> edges, Graph truth, Graph estimate,
-            int start, int end) {
+                                                int start, int end) {
         if (start == end) {
             Edge edge = edges.get(start);
             Node n1 = truth.getNode(edge.getNode1().toString());
@@ -252,7 +252,7 @@ public class GeneralResamplingTest {
      * Sets the background knowledge.
      *
      * @param knowledge the knowledge object, specifying forbidden and required
-     * edges.
+     *                  edges.
      */
     public void setKnowledge(Knowledge knowledge) {
         this.knowledge = new Knowledge(knowledge);
@@ -268,7 +268,7 @@ public class GeneralResamplingTest {
     public Graph search() {
         long start, stop;
 
-        start =  MillisecondTimes.timeMillis();
+        start = MillisecondTimes.timeMillis();
 
         if (this.algorithm != null) {
             this.resamplingSearch.setAlgorithm(this.algorithm);
@@ -311,15 +311,15 @@ public class GeneralResamplingTest {
             this.out.println("Processing time of total resamplings : " + (stop - start) / 1000.0 + " sec");
         }
 
-        start =  MillisecondTimes.timeMillis();
+        start = MillisecondTimes.timeMillis();
         Graph graph = GraphTools.createHighEdgeProbabilityGraph(this.graphs, edgeEnsemble);
         stop = MillisecondTimes.timeMillis();
-        if (this.verbose) {
-            this.out.println("Final Resampling Search Result:");
-            this.out.println(GraphUtils.graphToText(graph, false));
-            this.out.println();
-            this.out.println("probDistribution finished in " + (stop - start) + " ms");
-        }
+
+//        if (this.verbose) {
+        TetradLogger.getInstance().forceLogMessage("Final Resampling Search Result:");
+        TetradLogger.getInstance().forceLogMessage(GraphUtils.graphToText(graph, false));
+        TetradLogger.getInstance().forceLogMessage("probDistribution finished in " + (stop - start) + " ms");
+//        }
 
         return graph;
     }


### PR DESCRIPTION
1. Making sure verbose is not set to true by any algorithm. (Tests are fine.)

2. Making sure the final bootstrap output is printed out to the logs (and console output) whether verbose is set to true or not.