### PR TITLE
Some adjustments to get large BOSS1 runs to work in the GUI.

### DIFF
--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -7246,7 +7246,7 @@ tabs will not appear.</p> -->
             <li>Long Description: <span id="zSRiskBound_long_desc">
                 This is the probability of getting the true model if a correct model is discovered. Could underfit.</span>
             </li>
-            <li>Default Value: <span id="zSRiskBound_default_value">0.001</span></li>
+            <li>Default Value: <span id="zSRiskBound_default_value">0.1</span></li>
             <li>Lower Bound: <span id="zSRiskBound_lower_bound">0</span></li>
             <li>Upper Bound: <span id="zSRiskBound_upper_bound">1</span></li>
             <li>Value Type: <span id="zSRiskBound_value_type">Double</span></li>

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/StatsListEditor.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/StatsListEditor.java
@@ -172,15 +172,15 @@ public class StatsListEditor extends JPanel {
 
 
         // Greg table
-        statistics.add(new AncestorPrecision());
-        statistics.add(new AncestorRecall());
-        statistics.add(new AncestorF1());
-        statistics.add(new SemidirectedPrecision());
-        statistics.add(new SemidirectedRecall());
-        statistics.add(new SemidirectedPathF1());
-        statistics.add(new NoSemidirectedPrecision());
-        statistics.add(new NoSemidirectedRecall());
-        statistics.add(new NoSemidirectedF1());
+//        statistics.add(new AncestorPrecision());
+//        statistics.add(new AncestorRecall());
+//        statistics.add(new AncestorF1());
+//        statistics.add(new SemidirectedPrecision());
+//        statistics.add(new SemidirectedRecall());
+//        statistics.add(new SemidirectedPathF1());
+//        statistics.add(new NoSemidirectedPrecision());
+//        statistics.add(new NoSemidirectedRecall());
+//        statistics.add(new NoSemidirectedF1());
 
 //        statistics.add(new LegalPag());
 

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/examples/TestBoss.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/examples/TestBoss.java
@@ -44,10 +44,10 @@ import edu.cmu.tetrad.util.Params;
 public class TestBoss {
     public static void main(String... args) {
         Parameters parameters = new Parameters();
-        parameters.set(Params.NUM_RUNS, 10);
+        parameters.set(Params.NUM_RUNS, 1);
         parameters.set(Params.DIFFERENT_GRAPHS, true);
-        parameters.set(Params.NUM_MEASURES, 60);
-        parameters.set(Params.AVG_DEGREE, 6);
+        parameters.set(Params.NUM_MEASURES, 400);
+        parameters.set(Params.AVG_DEGREE, 20);
         parameters.set(Params.SAMPLE_SIZE, 1000);
         parameters.set(Params.COEF_LOW, 0);
         parameters.set(Params.COEF_HIGH, 1);
@@ -58,7 +58,7 @@ public class TestBoss {
         parameters.set(Params.SEM_BIC_STRUCTURE_PRIOR, 0);
         parameters.set(Params.ALPHA, 1e-2);
 
-        parameters.set("verbose", false);
+        parameters.set("verbose", true);
 
         Statistics statistics = new Statistics();
         statistics.add(new AdjacencyPrecision());
@@ -68,9 +68,9 @@ public class TestBoss {
         statistics.add(new ElapsedCpuTime());
 
         Algorithms algorithms = new Algorithms();
-        algorithms.add(new Fges(new SemBicScore()));
+//        algorithms.add(new Fges(new SemBicScore()));
         algorithms.add(new BDCE(new SemBicScore()));
-        algorithms.add(new BOSSDC(new SemBicScore()));
+//        algorithms.add(new BOSSDC(new SemBicScore()));
 
         Simulations simulations = new Simulations();
         simulations.add(new SemSimulation(new RandomForward()));

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/Boss.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/Boss.java
@@ -36,6 +36,7 @@ public class Boss {
     private int numStarts = 1;
     private AlgType algType = AlgType.BOSS1;
     private boolean caching = true;
+    private double epsilon = 1e-10;
 
     public Boss(@NotNull IndependenceTest test, Score score) {
         this.test = test;
@@ -103,17 +104,26 @@ public class Boss {
 
                 if (algType == AlgType.BOSS1) {
                     betterMutation1(scorer);
-                    besMutation(scorer);
+
+                    if (scorer.score() > s1 + epsilon) {
+                        besMutation(scorer);
+                    }
                 } else if (algType == AlgType.BOSS2) {
                     betterMutation2(scorer);
-                    besMutation(scorer);
+
+                    if (scorer.score() > s1 + epsilon) {
+                        besMutation(scorer);
+                    }
                 } else if (algType == AlgType.BOSS3) {
                     betterMutationBryan(scorer);
-                    besMutation(scorer);
+
+                    if (scorer.score() > s1 + epsilon) {
+                        besMutation(scorer);
+                    }
                 }
 
                 s2 = scorer.score();
-            } while (s2 > s1 || (++count <= 5));
+            } while (s2 > s1 + epsilon || (ensureMinimumCount && ++count <= 5));
 
             if (this.scorer.score() > best) {
                 best = this.scorer.score();
@@ -210,14 +220,14 @@ public class Boss {
 
             for (int i = 1; i < scorer.size(); i++) {
                 Node x = scorer.get(i);
-//                if (!introns1.contains(x)) continue;
+                if (!introns1.contains(x)) continue;
 
                 for (int j = i - 1; j >= 0; j--) {
                     if (!scorer.adjacent(scorer.get(j), x)) continue;
 
                     tuck(x, j, scorer, range);
 
-                    if (scorer.score() > bestScore || violatesKnowledge(scorer.getPi())) {
+                    if (scorer.score() > bestScore + epsilon || violatesKnowledge(scorer.getPi())) {
                         for (int l = range[0]; l <= range[1]; l++) {
                             introns2.add(scorer.get(l));
                         }
@@ -236,7 +246,7 @@ public class Boss {
             if (verbose) {
                 System.out.println();
             }
-        } while (bestScore > originalScore);
+        } while (bestScore > originalScore + epsilon);
     }
 
 
@@ -261,12 +271,12 @@ public class Boss {
                 double _sp = NEGATIVE_INFINITY;
                 scorer.bookmark();
 
-//                if (!introns1.contains(k)) continue;
+                if (!introns1.contains(k)) continue;
 
                 for (int j = 0; j < scorer.size(); j++) {
                     scorer.moveTo(k, j);
 
-                    if (scorer.score() >= _sp) {
+                    if (scorer.score() >= _sp + epsilon) {
                         if (!violatesKnowledge(scorer.getPi())) {
                             _sp = scorer.score();
                             scorer.bookmark();
@@ -292,7 +302,7 @@ public class Boss {
             }
 
             s2 = scorer.score();
-        } while (s2 > s1);
+        } while (s2 > s1 + epsilon);
 
         scorer.goToBookmark(1);
     }

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/SearchGraphUtils.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/SearchGraphUtils.java
@@ -1818,56 +1818,57 @@ public final class SearchGraphUtils {
             if (!edge1.equals(edge2)) {
                 incorrect.add(adj);
 
-                if (SearchGraphUtils.isLegalPag(trueGraph).isLegalPag() && SearchGraphUtils.isLegalPag(targetGraph).isLegalPag()) {
-                    GraphUtils.addPagColoring(trueGraph);
-                    GraphUtils.addPagColoring(targetGraph);
-
-                    if (edge2 == null) continue;
-
-                    if (GraphUtils.compatible(edge1, edge2)) {
-                        compatible.add(edge1);
-                    } else {
-                        incompatible.add(edge1);
-                    }
-                }
+//                if (SearchGraphUtils.isLegalPag(trueGraph).isLegalPag() && SearchGraphUtils.isLegalPag(targetGraph).isLegalPag()) {
+//                    GraphUtils.addPagColoring(trueGraph);
+//                    GraphUtils.addPagColoring(targetGraph);
+//
+//                    if (edge2 == null) continue;
+//
+//                    if (GraphUtils.compatible(edge1, edge2)) {
+//                        compatible.add(edge1);
+//                    } else {
+//                        incompatible.add(edge1);
+//                    }
+//                }
             }
         }
 
-        if (SearchGraphUtils.isLegalPag(trueGraph).isLegalPag() && SearchGraphUtils.isLegalPag(targetGraph).isLegalPag()) {
-            builder.append("\n\n" + "Edges incorrectly oriented (incompatible)");
-
-            if (incompatible.isEmpty()) {
-                builder.append("\n  --NONE--");
-            } else {
-                sort(incompatible);
-
-                int j1 = 0;
-
-                for (Edge adj : incompatible) {
-                    Edge edge1 = trueGraph.getEdge(adj.getNode1(), adj.getNode2());
-                    Edge edge2 = targetGraph.getEdge(adj.getNode1(), adj.getNode2());
-                    if (edge1 == null || edge2 == null) continue;
-                    builder.append("\n").append(++j1).append(". ").append(edge1).append(" ====> ").append(edge2);
-                }
-            }
-
-            builder.append("\n\n" + "Edges incorrectly oriented (compatible)");
-
-            sort(compatible);
-
-            if (compatible.isEmpty()) {
-                builder.append("\n  --NONE--");
-            } else {
-                int j1 = 0;
-
-                for (Edge adj : compatible) {
-                    Edge edge1 = trueGraph.getEdge(adj.getNode1(), adj.getNode2());
-                    Edge edge2 = targetGraph.getEdge(adj.getNode1(), adj.getNode2());
-                    if (edge1 == null || edge2 == null) continue;
-                    builder.append("\n").append(++j1).append(". ").append(edge1).append(" ====> ").append(edge2);
-                }
-            }
-        } else {
+//        if (SearchGraphUtils.isLegalPag(trueGraph).isLegalPag() && SearchGraphUtils.isLegalPag(targetGraph).isLegalPag()) {
+//            builder.append("\n\n" + "Edges incorrectly oriented (incompatible)");
+//
+//            if (incompatible.isEmpty()) {
+//                builder.append("\n  --NONE--");
+//            } else {
+//                sort(incompatible);
+//
+//                int j1 = 0;
+//
+//                for (Edge adj : incompatible) {
+//                    Edge edge1 = trueGraph.getEdge(adj.getNode1(), adj.getNode2());
+//                    Edge edge2 = targetGraph.getEdge(adj.getNode1(), adj.getNode2());
+//                    if (edge1 == null || edge2 == null) continue;
+//                    builder.append("\n").append(++j1).append(". ").append(edge1).append(" ====> ").append(edge2);
+//                }
+//            }
+//
+//            builder.append("\n\n" + "Edges incorrectly oriented (compatible)");
+//
+//            sort(compatible);
+//
+//            if (compatible.isEmpty()) {
+//                builder.append("\n  --NONE--");
+//            } else {
+//                int j1 = 0;
+//
+//                for (Edge adj : compatible) {
+//                    Edge edge1 = trueGraph.getEdge(adj.getNode1(), adj.getNode2());
+//                    Edge edge2 = targetGraph.getEdge(adj.getNode1(), adj.getNode2());
+//                    if (edge1 == null || edge2 == null) continue;
+//                    builder.append("\n").append(++j1).append(". ").append(edge1).append(" ====> ").append(edge2);
+//                }
+//            }
+//        } else
+        {
             builder.append("\n\n" + "Edges incorrectly oriented");
 
             if (incorrect.isEmpty()) {


### PR DESCRIPTION
1. Put intron reasoning back in BOSS
1. Do BES for BOSS only if better mutation improves the score.
1. Took out isLegalPag() calls in Edgewise comparison; this hangs the interface for large graphs.
1. Removed path statistics from the Stats List comparison, as they hang the interface for large graph.
1. Changing default for ZSB risk bound to 0.1.
1. For BOSS1 and BOSS2, added an epsilon to score comparisons (default 1e-10).