### PR TITLE
A Fix for Unit Tests Running in Windows.

### DIFF
--- a/data-reader/src/test/java/edu/pitt/dbmi/data/reader/DataColumnsTest.java
+++ b/data-reader/src/test/java/edu/pitt/dbmi/data/reader/DataColumnsTest.java
@@ -23,12 +23,12 @@ import edu.pitt.dbmi.data.reader.metadata.MetadataFileReader;
 import edu.pitt.dbmi.data.reader.metadata.MetadataReader;
 import edu.pitt.dbmi.data.reader.tabular.TabularColumnFileReader;
 import edu.pitt.dbmi.data.reader.tabular.TabularColumnReader;
+import java.io.File;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 /**
  * Jan 2, 2019 10:49:19 AM
@@ -37,8 +37,8 @@ import java.nio.file.Paths;
  */
 public class DataColumnsTest {
 
-    Path dataFile = Paths.get(getClass().getResource("/data/metadata/sim_mixed_intervention.txt").getFile());
-    Path metadataFile = Paths.get(getClass().getResource("/data/metadata/sim_mixed_intervention_metadata.json").getFile());
+    Path dataFile = new File(getClass().getResource("/data/metadata/sim_mixed_intervention.txt").getFile()).toPath();
+    Path metadataFile = new File(getClass().getResource("/data/metadata/sim_mixed_intervention_metadata.json").getFile()).toPath();
 
     private final Delimiter delimiter = Delimiter.TAB;
 

--- a/data-reader/src/test/java/edu/pitt/dbmi/data/reader/covariance/LowerCovarianceDataFileReaderTest.java
+++ b/data-reader/src/test/java/edu/pitt/dbmi/data/reader/covariance/LowerCovarianceDataFileReaderTest.java
@@ -19,13 +19,12 @@
 package edu.pitt.dbmi.data.reader.covariance;
 
 import edu.pitt.dbmi.data.reader.Delimiter;
-import org.junit.Assert;
-import org.junit.Test;
-
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * Dec 7, 2018 4:39:33 PM
@@ -37,8 +36,8 @@ public class LowerCovarianceDataFileReaderTest {
     private final Delimiter delimiter = Delimiter.SPACE;
 
     private final Path[] dataFiles = {
-            Paths.get(getClass().getResource("/data/covariance/spartina.txt").getFile()),
-            Paths.get(getClass().getResource("/data/covariance/quotes_spartina.txt").getFile())
+        new File(getClass().getResource("/data/covariance/spartina.txt").getFile()).toPath(),
+        new File(getClass().getResource("/data/covariance/quotes_spartina.txt").getFile()).toPath()
     };
 
     public LowerCovarianceDataFileReaderTest() {

--- a/data-reader/src/test/java/edu/pitt/dbmi/data/reader/metadata/MetadataFileReaderTest.java
+++ b/data-reader/src/test/java/edu/pitt/dbmi/data/reader/metadata/MetadataFileReaderTest.java
@@ -18,13 +18,12 @@
  */
 package edu.pitt.dbmi.data.reader.metadata;
 
-import org.junit.Assert;
-import org.junit.Test;
-
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * Dec 18, 2018 2:22:25 PM
@@ -33,7 +32,7 @@ import java.util.List;
  */
 public class MetadataFileReaderTest {
 
-    private final Path metadataFile = Paths.get(getClass().getResource("/data/metadata/sim_mixed_intervention_metadata.json").getFile());
+    private final Path metadataFile = new File(getClass().getResource("/data/metadata/sim_mixed_intervention_metadata.json").getFile()).toPath();
 
     public MetadataFileReaderTest() {
     }

--- a/data-reader/src/test/java/edu/pitt/dbmi/data/reader/metadata/MetadataFileWriterTest.java
+++ b/data-reader/src/test/java/edu/pitt/dbmi/data/reader/metadata/MetadataFileWriterTest.java
@@ -19,14 +19,13 @@
 package edu.pitt.dbmi.data.reader.metadata;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import org.junit.Assert;
-import org.junit.Test;
-
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.LinkedList;
 import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * Dec 18, 2018 2:48:02 PM
@@ -35,7 +34,7 @@ import java.util.List;
  */
 public class MetadataFileWriterTest {
 
-    private final Path metadataFile = Paths.get(getClass().getResource("/data/metadata/sim_mixed_intervention_metadata.json").getFile());
+    private final Path metadataFile = new File(getClass().getResource("/data/metadata/sim_mixed_intervention_metadata.json").getFile()).toPath();
 
     public MetadataFileWriterTest() {
     }

--- a/data-reader/src/test/java/edu/pitt/dbmi/data/reader/preview/BasicDataPreviewerTest.java
+++ b/data-reader/src/test/java/edu/pitt/dbmi/data/reader/preview/BasicDataPreviewerTest.java
@@ -18,13 +18,12 @@
  */
 package edu.pitt.dbmi.data.reader.preview;
 
-import org.junit.Assert;
-import org.junit.Test;
-
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * Mar 6, 2017 8:41:16 PM
@@ -43,7 +42,7 @@ public class BasicDataPreviewerTest {
      */
     @Test
     public void testGetPreviews() throws IOException {
-        Path dataFile = Paths.get(getClass().getResource("/data/tabular/continuous/sim_test_data.csv").getFile());
+        Path dataFile = new File(getClass().getResource("/data/tabular/continuous/sim_test_data.csv").getFile()).toPath();
 
         DataPreviewer dataPreviewer = new BasicDataPreviewer(dataFile);
 

--- a/data-reader/src/test/java/edu/pitt/dbmi/data/reader/tabular/ContinuousTabularDatasetFileReaderTest.java
+++ b/data-reader/src/test/java/edu/pitt/dbmi/data/reader/tabular/ContinuousTabularDatasetFileReaderTest.java
@@ -22,15 +22,14 @@ import edu.pitt.dbmi.data.reader.ContinuousData;
 import edu.pitt.dbmi.data.reader.Data;
 import edu.pitt.dbmi.data.reader.DataColumn;
 import edu.pitt.dbmi.data.reader.Delimiter;
-import org.junit.Assert;
-import org.junit.Test;
-
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * Jan 2, 2019 2:19:53 PM
@@ -46,10 +45,10 @@ public class ContinuousTabularDatasetFileReaderTest {
     private final boolean hasHeader = true;
 
     private final Path[] dataFiles = {
-            Paths.get(getClass().getResource("/data/tabular/continuous/dos_sim_test_data.csv").getFile()),
-            Paths.get(getClass().getResource("/data/tabular/continuous/mac_sim_test_data.csv").getFile()),
-            Paths.get(getClass().getResource("/data/tabular/continuous/sim_test_data.csv").getFile()),
-            Paths.get(getClass().getResource("/data/tabular/continuous/quotes_sim_test_data.csv").getFile())
+        new File(getClass().getResource("/data/tabular/continuous/dos_sim_test_data.csv").getFile()).toPath(),
+        new File(getClass().getResource("/data/tabular/continuous/mac_sim_test_data.csv").getFile()).toPath(),
+        new File(getClass().getResource("/data/tabular/continuous/sim_test_data.csv").getFile()).toPath(),
+        new File(getClass().getResource("/data/tabular/continuous/quotes_sim_test_data.csv").getFile()).toPath()
     };
 
     public ContinuousTabularDatasetFileReaderTest() {
@@ -62,7 +61,7 @@ public class ContinuousTabularDatasetFileReaderTest {
      */
     @Test
     public void testReadInDataWithNoHeaderExcludingVariableByColumnNumbers() throws IOException {
-        Path dataFile = Paths.get(getClass().getResource("/data/tabular/continuous/no_header_sim_test_data.csv").getFile());
+        Path dataFile = new File(getClass().getResource("/data/tabular/continuous/no_header_sim_test_data.csv").getFile()).toPath();
         ContinuousTabularDatasetReader dataReader = new ContinuousTabularDatasetFileReader(dataFile, this.delimiter);
         dataReader.setCommentMarker(this.commentMarker);
         dataReader.setQuoteCharacter(this.quoteCharacter);
@@ -97,7 +96,7 @@ public class ContinuousTabularDatasetFileReaderTest {
      */
     @Test
     public void testReadInDataWithNoHeader() throws IOException {
-        Path dataFile = Paths.get(getClass().getResource("/data/tabular/continuous/no_header_sim_test_data.csv").getFile());
+        Path dataFile = new File(getClass().getResource("/data/tabular/continuous/no_header_sim_test_data.csv").getFile()).toPath();
         ContinuousTabularDatasetReader dataReader = new ContinuousTabularDatasetFileReader(dataFile, this.delimiter);
         dataReader.setCommentMarker(this.commentMarker);
         dataReader.setQuoteCharacter(this.quoteCharacter);

--- a/data-reader/src/test/java/edu/pitt/dbmi/data/reader/tabular/MixedTabularDatasetFileReaderTest.java
+++ b/data-reader/src/test/java/edu/pitt/dbmi/data/reader/tabular/MixedTabularDatasetFileReaderTest.java
@@ -21,15 +21,14 @@ package edu.pitt.dbmi.data.reader.tabular;
 import edu.pitt.dbmi.data.reader.Data;
 import edu.pitt.dbmi.data.reader.Delimiter;
 import edu.pitt.dbmi.data.reader.DiscreteDataColumn;
-import org.junit.Assert;
-import org.junit.Test;
-
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * Jan 2, 2019 4:03:44 PM
@@ -46,10 +45,10 @@ public class MixedTabularDatasetFileReaderTest {
     private final int numberOfDiscreteCategories = 4;
 
     private final Path[] dataFiles = {
-            Paths.get(getClass().getResource("/data/tabular/mixed/dos_sim_test_data.csv").getFile()),
-            Paths.get(getClass().getResource("/data/tabular/mixed/mac_sim_test_data.csv").getFile()),
-            Paths.get(getClass().getResource("/data/tabular/mixed/sim_test_data.csv").getFile()),
-            Paths.get(getClass().getResource("/data/tabular/mixed/quotes_sim_test_data.csv").getFile())
+        new File(getClass().getResource("/data/tabular/mixed/dos_sim_test_data.csv").getFile()).toPath(),
+        new File(getClass().getResource("/data/tabular/mixed/mac_sim_test_data.csv").getFile()).toPath(),
+        new File(getClass().getResource("/data/tabular/mixed/sim_test_data.csv").getFile()).toPath(),
+        new File(getClass().getResource("/data/tabular/mixed/quotes_sim_test_data.csv").getFile()).toPath()
     };
 
     public MixedTabularDatasetFileReaderTest() {
@@ -62,7 +61,7 @@ public class MixedTabularDatasetFileReaderTest {
      */
     @Test
     public void testReadInDataWithNoHeader() throws IOException {
-        Path dataFile = Paths.get(getClass().getResource("/data/tabular/mixed/no_header_sim_test_data.csv").getFile());
+        Path dataFile = new File(getClass().getResource("/data/tabular/mixed/no_header_sim_test_data.csv").getFile()).toPath();
         MixedTabularDatasetReader dataReader = new MixedTabularDatasetFileReader(dataFile, this.delimiter, this.numberOfDiscreteCategories);
         dataReader.setCommentMarker(this.commentMarker);
         dataReader.setQuoteCharacter(this.quoteCharacter);
@@ -111,7 +110,7 @@ public class MixedTabularDatasetFileReaderTest {
      */
     @Test
     public void testReadInDataWithNoHeaderExcludingVariableByColumnNumbers() throws IOException {
-        Path dataFile = Paths.get(getClass().getResource("/data/tabular/mixed/no_header_sim_test_data.csv").getFile());
+        Path dataFile = new File(getClass().getResource("/data/tabular/mixed/no_header_sim_test_data.csv").getFile()).toPath();
         MixedTabularDatasetReader dataReader = new MixedTabularDatasetFileReader(dataFile, this.delimiter, this.numberOfDiscreteCategories);
         dataReader.setCommentMarker(this.commentMarker);
         dataReader.setQuoteCharacter(this.quoteCharacter);

--- a/data-reader/src/test/java/edu/pitt/dbmi/data/reader/tabular/TabularColumnFileReaderTest.java
+++ b/data-reader/src/test/java/edu/pitt/dbmi/data/reader/tabular/TabularColumnFileReaderTest.java
@@ -20,16 +20,15 @@ package edu.pitt.dbmi.data.reader.tabular;
 
 import edu.pitt.dbmi.data.reader.DataColumn;
 import edu.pitt.dbmi.data.reader.Delimiter;
-import org.junit.Assert;
-import org.junit.Test;
-
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * Dec 9, 2018 2:07:46 PM
@@ -43,10 +42,10 @@ public class TabularColumnFileReaderTest {
     private final String commentMarker = "//";
 
     private final Path[] dataFiles = {
-            Paths.get(getClass().getResource("/data/tabular/mixed/dos_sim_test_data.csv").getFile()),
-            Paths.get(getClass().getResource("/data/tabular/mixed/mac_sim_test_data.csv").getFile()),
-            Paths.get(getClass().getResource("/data/tabular/mixed/sim_test_data.csv").getFile()),
-            Paths.get(getClass().getResource("/data/tabular/mixed/quotes_sim_test_data.csv").getFile())
+        new File(getClass().getResource("/data/tabular/mixed/dos_sim_test_data.csv").getFile()).toPath(),
+        new File(getClass().getResource("/data/tabular/mixed/mac_sim_test_data.csv").getFile()).toPath(),
+        new File(getClass().getResource("/data/tabular/mixed/sim_test_data.csv").getFile()).toPath(),
+        new File(getClass().getResource("/data/tabular/mixed/quotes_sim_test_data.csv").getFile()).toPath()
     };
 
     public TabularColumnFileReaderTest() {

--- a/data-reader/src/test/java/edu/pitt/dbmi/data/reader/tabular/TabularDataFileReaderTest.java
+++ b/data-reader/src/test/java/edu/pitt/dbmi/data/reader/tabular/TabularDataFileReaderTest.java
@@ -22,15 +22,14 @@ import edu.pitt.dbmi.data.reader.*;
 import edu.pitt.dbmi.data.reader.metadata.Metadata;
 import edu.pitt.dbmi.data.reader.metadata.MetadataFileReader;
 import edu.pitt.dbmi.data.reader.metadata.MetadataReader;
-import org.junit.Assert;
-import org.junit.Test;
-
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * Nov 15, 2018 5:22:50 PM
@@ -46,24 +45,24 @@ public class TabularDataFileReaderTest {
     private final boolean hasHeader = true;
 
     private final Path[] continuousDataFiles = {
-            Paths.get(getClass().getResource("/data/tabular/continuous/dos_sim_test_data.csv").getFile()),
-            Paths.get(getClass().getResource("/data/tabular/continuous/mac_sim_test_data.csv").getFile()),
-            Paths.get(getClass().getResource("/data/tabular/continuous/sim_test_data.csv").getFile()),
-            Paths.get(getClass().getResource("/data/tabular/continuous/quotes_sim_test_data.csv").getFile())
+        new File(getClass().getResource("/data/tabular/continuous/dos_sim_test_data.csv").getFile()).toPath(),
+        new File(getClass().getResource("/data/tabular/continuous/mac_sim_test_data.csv").getFile()).toPath(),
+        new File(getClass().getResource("/data/tabular/continuous/sim_test_data.csv").getFile()).toPath(),
+        new File(getClass().getResource("/data/tabular/continuous/quotes_sim_test_data.csv").getFile()).toPath()
     };
 
     private final Path[] discreteDataFiles = {
-            Paths.get(getClass().getResource("/data/tabular/discrete/dos_sim_test_data.csv").getFile()),
-            Paths.get(getClass().getResource("/data/tabular/discrete/mac_sim_test_data.csv").getFile()),
-            Paths.get(getClass().getResource("/data/tabular/discrete/sim_test_data.csv").getFile()),
-            Paths.get(getClass().getResource("/data/tabular/discrete/quotes_sim_test_data.csv").getFile())
+        new File(getClass().getResource("/data/tabular/discrete/dos_sim_test_data.csv").getFile()).toPath(),
+        new File(getClass().getResource("/data/tabular/discrete/mac_sim_test_data.csv").getFile()).toPath(),
+        new File(getClass().getResource("/data/tabular/discrete/sim_test_data.csv").getFile()).toPath(),
+        new File(getClass().getResource("/data/tabular/discrete/quotes_sim_test_data.csv").getFile()).toPath()
     };
 
     private final Path[] mixedDataFiles = {
-            Paths.get(getClass().getResource("/data/tabular/mixed/dos_sim_test_data.csv").getFile()),
-            Paths.get(getClass().getResource("/data/tabular/mixed/mac_sim_test_data.csv").getFile()),
-            Paths.get(getClass().getResource("/data/tabular/mixed/sim_test_data.csv").getFile()),
-            Paths.get(getClass().getResource("/data/tabular/mixed/quotes_sim_test_data.csv").getFile())
+        new File(getClass().getResource("/data/tabular/mixed/dos_sim_test_data.csv").getFile()).toPath(),
+        new File(getClass().getResource("/data/tabular/mixed/mac_sim_test_data.csv").getFile()).toPath(),
+        new File(getClass().getResource("/data/tabular/mixed/sim_test_data.csv").getFile()).toPath(),
+        new File(getClass().getResource("/data/tabular/mixed/quotes_sim_test_data.csv").getFile()).toPath()
     };
 
     public TabularDataFileReaderTest() {
@@ -71,8 +70,8 @@ public class TabularDataFileReaderTest {
 
     @Test
     public void testReadInContinuousDataWitMetadata() throws IOException {
-        Path dataFile = Paths.get(getClass().getResource("/data/metadata/sim_continuous_intervention.txt").getFile());
-        Path metadataFile = Paths.get(getClass().getResource("/data/metadata/sim_continuous_intervention_metadata.json").getFile());
+        Path dataFile = new File(getClass().getResource("/data/metadata/sim_continuous_intervention.txt").getFile()).toPath();
+        Path metadataFile = new File(getClass().getResource("/data/metadata/sim_continuous_intervention_metadata.json").getFile()).toPath();
 
         TabularColumnReader columnReader = new TabularColumnFileReader(dataFile, Delimiter.TAB);
         DataColumn[] dataColumns = columnReader.readInDataColumns(false);
@@ -111,8 +110,8 @@ public class TabularDataFileReaderTest {
 
     @Test
     public void testReadInDiscreteDataWitMetadata() throws IOException {
-        Path dataFile = Paths.get(getClass().getResource("/data/metadata/sim_discrete_intervention.txt").getFile());
-        Path metadataFile = Paths.get(getClass().getResource("/data/metadata/sim_discrete_intervention_metadata.json").getFile());
+        Path dataFile = new File(getClass().getResource("/data/metadata/sim_discrete_intervention.txt").getFile()).toPath();
+        Path metadataFile = new File(getClass().getResource("/data/metadata/sim_discrete_intervention_metadata.json").getFile()).toPath();
 
         TabularColumnReader columnReader = new TabularColumnFileReader(dataFile, Delimiter.TAB);
         DataColumn[] dataColumns = columnReader.readInDataColumns(true);
@@ -151,8 +150,8 @@ public class TabularDataFileReaderTest {
 
     @Test
     public void testReadInSampleMixedDataWitMetadata() throws IOException {
-        Path dataFile = Paths.get(getClass().getResource("/data/metadata/sample_dataset.txt").getFile());
-        Path metadataFile = Paths.get(getClass().getResource("/data/metadata/sample_metadata.json").getFile());
+        Path dataFile = new File(getClass().getResource("/data/metadata/sample_dataset.txt").getFile()).toPath();
+        Path metadataFile = new File(getClass().getResource("/data/metadata/sample_metadata.json").getFile()).toPath();
 
         TabularColumnReader columnReader = new TabularColumnFileReader(dataFile, Delimiter.TAB);
         DataColumn[] dataColumns = columnReader.readInDataColumns(true);
@@ -223,8 +222,8 @@ public class TabularDataFileReaderTest {
      */
     @Test
     public void testReadInMixedDataWitMetadata() throws IOException {
-        Path dataFile = Paths.get(getClass().getResource("/data/metadata/sim_mixed_intervention.txt").getFile());
-        Path metadataFile = Paths.get(getClass().getResource("/data/metadata/sim_mixed_intervention_metadata.json").getFile());
+        Path dataFile = new File(getClass().getResource("/data/metadata/sim_mixed_intervention.txt").getFile()).toPath();
+        Path metadataFile = new File(getClass().getResource("/data/metadata/sim_mixed_intervention_metadata.json").getFile()).toPath();
 
         TabularColumnReader columnReader = new TabularColumnFileReader(dataFile, Delimiter.TAB);
         DataColumn[] dataColumns = columnReader.readInDataColumns(true);

--- a/data-reader/src/test/java/edu/pitt/dbmi/data/reader/tabular/VerticalDiscreteTabularDatasetFileReaderTest.java
+++ b/data-reader/src/test/java/edu/pitt/dbmi/data/reader/tabular/VerticalDiscreteTabularDatasetFileReaderTest.java
@@ -22,15 +22,14 @@ import edu.pitt.dbmi.data.reader.Data;
 import edu.pitt.dbmi.data.reader.Delimiter;
 import edu.pitt.dbmi.data.reader.DiscreteData;
 import edu.pitt.dbmi.data.reader.DiscreteDataColumn;
-import org.junit.Assert;
-import org.junit.Test;
-
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * Jan 2, 2019 2:57:44 PM
@@ -46,10 +45,10 @@ public class VerticalDiscreteTabularDatasetFileReaderTest {
     private final boolean hasHeader = true;
 
     private final Path[] dataFiles = {
-            Paths.get(getClass().getResource("/data/tabular/discrete/dos_sim_test_data.csv").getFile()),
-            Paths.get(getClass().getResource("/data/tabular/discrete/mac_sim_test_data.csv").getFile()),
-            Paths.get(getClass().getResource("/data/tabular/discrete/sim_test_data.csv").getFile()),
-            Paths.get(getClass().getResource("/data/tabular/discrete/quotes_sim_test_data.csv").getFile())
+        new File(getClass().getResource("/data/tabular/discrete/dos_sim_test_data.csv").getFile()).toPath(),
+        new File(getClass().getResource("/data/tabular/discrete/mac_sim_test_data.csv").getFile()).toPath(),
+        new File(getClass().getResource("/data/tabular/discrete/sim_test_data.csv").getFile()).toPath(),
+        new File(getClass().getResource("/data/tabular/discrete/quotes_sim_test_data.csv").getFile()).toPath()
     };
 
     public VerticalDiscreteTabularDatasetFileReaderTest() {
@@ -62,7 +61,7 @@ public class VerticalDiscreteTabularDatasetFileReaderTest {
      */
     @Test
     public void testReadInDataWithNoHeaderExcludingVariableByColumnNumbers() throws IOException {
-        Path dataFile = Paths.get(getClass().getResource("/data/tabular/discrete/no_header_sim_test_data.csv").getFile());
+        Path dataFile = new File(getClass().getResource("/data/tabular/discrete/no_header_sim_test_data.csv").getFile()).toPath();
         VerticalDiscreteTabularDatasetReader dataReader = new VerticalDiscreteTabularDatasetFileReader(dataFile, this.delimiter);
         dataReader.setCommentMarker(this.commentMarker);
         dataReader.setQuoteCharacter(this.quoteCharacter);
@@ -97,7 +96,7 @@ public class VerticalDiscreteTabularDatasetFileReaderTest {
      */
     @Test
     public void testReadInDataWithNoHeader() throws IOException {
-        Path dataFile = Paths.get(getClass().getResource("/data/tabular/discrete/no_header_sim_test_data.csv").getFile());
+        Path dataFile = new File(getClass().getResource("/data/tabular/discrete/no_header_sim_test_data.csv").getFile()).toPath();
         VerticalDiscreteTabularDatasetReader dataReader = new VerticalDiscreteTabularDatasetFileReader(dataFile, this.delimiter);
         dataReader.setCommentMarker(this.commentMarker);
         dataReader.setQuoteCharacter(this.quoteCharacter);

--- a/data-reader/src/test/java/edu/pitt/dbmi/data/reader/validation/covariance/LowerCovarianceDataFileValidationTest.java
+++ b/data-reader/src/test/java/edu/pitt/dbmi/data/reader/validation/covariance/LowerCovarianceDataFileValidationTest.java
@@ -20,13 +20,12 @@ package edu.pitt.dbmi.data.reader.validation.covariance;
 
 import edu.pitt.dbmi.data.reader.Delimiter;
 import edu.pitt.dbmi.data.reader.validation.ValidationResult;
-import org.junit.Assert;
-import org.junit.Test;
-
+import java.io.File;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.LinkedList;
 import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * Nov 20, 2018 2:04:40 PM
@@ -37,7 +36,7 @@ public class LowerCovarianceDataFileValidationTest {
 
     private final Delimiter delimiter = Delimiter.SPACE;
 
-    private final Path dataFile = Paths.get(getClass().getResource("/data/covariance/bad_spartina.txt").getFile());
+    private final Path dataFile = new File(getClass().getResource("/data/covariance/bad_spartina.txt").getFile()).toPath();
 
     public LowerCovarianceDataFileValidationTest() {
     }

--- a/data-reader/src/test/java/edu/pitt/dbmi/data/reader/validation/tabular/TabularColumnFileValidationTest.java
+++ b/data-reader/src/test/java/edu/pitt/dbmi/data/reader/validation/tabular/TabularColumnFileValidationTest.java
@@ -20,12 +20,11 @@ package edu.pitt.dbmi.data.reader.validation.tabular;
 
 import edu.pitt.dbmi.data.reader.Delimiter;
 import edu.pitt.dbmi.data.reader.validation.ValidationResult;
+import java.io.File;
+import java.nio.file.Path;
+import java.util.*;
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.*;
 
 /**
  * Dec 12, 2018 4:16:55 PM
@@ -38,7 +37,7 @@ public class TabularColumnFileValidationTest {
     private final char quoteCharacter = '"';
     private final String commentMarker = "//";
 
-    private final Path dataFile = Paths.get(getClass().getResource("/data/tabular/continuous/bad_column_sim_test_data.csv").getFile());
+    private final Path dataFile = new File(getClass().getResource("/data/tabular/continuous/bad_column_sim_test_data.csv").getFile()).toPath();
 
     public TabularColumnFileValidationTest() {
     }

--- a/data-reader/src/test/java/edu/pitt/dbmi/data/reader/validation/tabular/TabularDataFileValidationTest.java
+++ b/data-reader/src/test/java/edu/pitt/dbmi/data/reader/validation/tabular/TabularDataFileValidationTest.java
@@ -29,14 +29,13 @@ import edu.pitt.dbmi.data.reader.tabular.TabularColumnReader;
 import edu.pitt.dbmi.data.reader.tabular.TabularDataFileReader;
 import edu.pitt.dbmi.data.reader.tabular.TabularDataReader;
 import edu.pitt.dbmi.data.reader.validation.ValidationResult;
-import org.junit.Assert;
-import org.junit.Test;
-
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.LinkedList;
 import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * Dec 12, 2018 11:11:32 PM
@@ -51,22 +50,22 @@ public class TabularDataFileValidationTest {
     private final String commentMarker = "//";
     private final boolean hasHeader = true;
 
-    private final Path continuousDataFile = Paths.get(getClass()
-            .getResource("/data/tabular/continuous/bad_data_sim_test_data.csv").getFile());
+    private final Path continuousDataFile = new File(getClass()
+            .getResource("/data/tabular/continuous/bad_data_sim_test_data.csv").getFile()).toPath();
 
-    private final Path discreteDataFile = Paths.get(getClass()
-            .getResource("/data/tabular/discrete/bad_data_sim_test_data.csv").getFile());
+    private final Path discreteDataFile = new File(getClass()
+            .getResource("/data/tabular/discrete/bad_data_sim_test_data.csv").getFile()).toPath();
 
-    private final Path mixedDataFile = Paths.get(getClass()
-            .getResource("/data/tabular/mixed/bad_data_sim_test_data.csv").getFile());
+    private final Path mixedDataFile = new File(getClass()
+            .getResource("/data/tabular/mixed/bad_data_sim_test_data.csv").getFile()).toPath();
 
     public TabularDataFileValidationTest() {
     }
 
     @Test
     public void testValidateForMixedDataWithDateColumn() throws IOException {
-        Path dataFile = Paths.get(getClass().getResource("/data/metadata/mixed_with_dates.csv").getFile());
-        Path metadataFile = Paths.get(getClass().getResource("/data/metadata/mixed_with_dates_metadata.json").getFile());
+        Path dataFile = new File(getClass().getResource("/data/metadata/mixed_with_dates.csv").getFile()).toPath();
+        Path metadataFile = new File(getClass().getResource("/data/metadata/mixed_with_dates_metadata.json").getFile()).toPath();
 
         List<ValidationResult> infos = new LinkedList<>();
         List<ValidationResult> warnings = new LinkedList<>();

--- a/tetrad-lib/src/test/java/edu/pitt/dbmi/algo/bayesian/constraint/inference/BcCausalInferenceTest.java
+++ b/tetrad-lib/src/test/java/edu/pitt/dbmi/algo/bayesian/constraint/inference/BcCausalInferenceTest.java
@@ -5,15 +5,14 @@
  */
 package edu.pitt.dbmi.algo.bayesian.constraint.inference;
 
-import org.junit.Assert;
-import org.junit.Test;
-
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.regex.Pattern;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * Jan 30, 2019 5:47:01 PM
@@ -32,7 +31,7 @@ public class BcCausalInferenceTest {
      */
     @Test
     public void testProbConstraint() throws IOException {
-        Path casFile = Paths.get(getClass().getResource("/cooper.data/small_data.cas").getFile());
+        Path casFile = new File(getClass().getResource("/cooper.data/small_data.cas").getFile()).toPath();
         int[] nodeDimension = BcCausalInferenceTest.readInNodeDimension(casFile);
         int[][] dataset = BcCausalInferenceTest.readInDataset(casFile);
 


### PR DESCRIPTION
Fixing the unit tests failures due to not reading the correct file path in Windows.  Thanks to @yasu-sh for the idea when fixing this in causal-cmd.