### PR TITLE
Adjusted Markov check and Descriptive Stats.

### DIFF
--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -4466,6 +4466,28 @@ tabs will not appear.</p> -->
                 <span id="addOriginalDataset_value_type">Boolean</span></li>
         </ul>
 
+        <h3 class="parameter_description"
+            id="saveBootstrapGraphs">saveBootstrapGraphs</h3>
+        <ul
+                class="parameter_description_list">
+            <li>Short Description: <span
+                    id="saveBootstrapGraphs_short_desc">Yes if individual bootstrapping
+                    graphs should be saved</span></li>
+            <li>Long Description: <span
+                    id="saveBootstrapGraphs_long_desc"> Bootstrapping provides a summary
+                    over individual search graphs; select Yes here if these individual
+                    graphs should be saved</span>
+            </li>
+            <li>Default Value: <span
+                    id="saveBootstrapGraphs_default_value">false</span></li>
+            <li>Lower
+                Bound: <span id="saveBootstrapGraphs_lower_bound"></span></li>
+            <li>Upper Bound: <span
+                    id="saveBootstrapGraphs_upper_bound"></span></li>
+            <li>Value Type:
+                <span id="saveBootstrapGraphs_value_type">Boolean</span></li>
+        </ul>
+
         <h3 class="parameter_description" id="alpha">alpha</h3>
         <ul
                 class="parameter_description_list">

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/DataEditor.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/DataEditor.java
@@ -644,7 +644,7 @@ public final class DataEditor extends JPanel implements KnowledgeEditable,
         tools.add(new PlotMatrixAction(this));
         tools.add(new DescriptiveStatsAction(this));
         tools.add(new QQPlotAction(this));
-o
+
         final int vkBackSpace = KeyEvent.VK_BACK_SPACE;
         final int vkDelete = KeyEvent.VK_DELETE;
 

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/DataEditor.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/DataEditor.java
@@ -642,9 +642,9 @@ public final class DataEditor extends JPanel implements KnowledgeEditable,
         menuBar.add(tools);
 
         tools.add(new PlotMatrixAction(this));
-        tools.add(new QQPlotAction(this));
         tools.add(new DescriptiveStatsAction(this));
-
+        tools.add(new QQPlotAction(this));
+o
         final int vkBackSpace = KeyEvent.VK_BACK_SPACE;
         final int vkDelete = KeyEvent.VK_DELETE;
 

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/DataEditor.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/DataEditor.java
@@ -645,7 +645,7 @@ public final class DataEditor extends JPanel implements KnowledgeEditable,
 //        tools.add(new HistogramAction(this));
         tools.add(new PlotMatrixAction(this));
         tools.add(new QQPlotAction(this));
-        tools.add(new NormalityTestAction(this));
+//        tools.add(new NormalityTestAction(this));
         tools.add(new DescriptiveStatsAction(this));
 
         final int vkBackSpace = KeyEvent.VK_BACK_SPACE;

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/DataEditor.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/DataEditor.java
@@ -61,7 +61,7 @@ public final class DataEditor extends JPanel implements KnowledgeEditable,
     private boolean showMenus = true;
     private final Parameters parameters;
 
-    //==========================CONSTUCTORS===============================//
+    //==========================CONSTRUCTORS===============================//
 
     /**
      * Constructs the data editor with an empty list of data displays.
@@ -160,7 +160,7 @@ public final class DataEditor extends JPanel implements KnowledgeEditable,
     //==========================PUBLIC METHODS=============================//
 
     /**
-     * Replaces the getModel Datamodels with the given one. Note, that by
+     * Replaces the Data models with the given one. Note, that by
      * calling this you are removing ALL the getModel data-models, they will be
      * lost forever!
      *
@@ -641,11 +641,8 @@ public final class DataEditor extends JPanel implements KnowledgeEditable,
         JMenu tools = new JMenu("Tools");
         menuBar.add(tools);
 
-//        tools.add(new CalculatorAction(this));
-//        tools.add(new HistogramAction(this));
         tools.add(new PlotMatrixAction(this));
         tools.add(new QQPlotAction(this));
-//        tools.add(new NormalityTestAction(this));
         tools.add(new DescriptiveStatsAction(this));
 
         final int vkBackSpace = KeyEvent.VK_BACK_SPACE;

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/DataEditor.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/DataEditor.java
@@ -457,8 +457,7 @@ public final class DataEditor extends JPanel implements KnowledgeEditable,
                 KeyStroke.getKeyStroke(KeyEvent.VK_V, InputEvent.CTRL_DOWN_MASK));
 
         clearCells.addActionListener(e -> {
-            TabularDataJTable table
-                    = (TabularDataJTable) getSelectedJTable();
+            TabularDataJTable table = (TabularDataJTable) getSelectedJTable();
             assert table != null;
             table.clearSelected();
         });
@@ -647,7 +646,7 @@ public final class DataEditor extends JPanel implements KnowledgeEditable,
         tools.add(new PlotMatrixAction(this));
         tools.add(new QQPlotAction(this));
         tools.add(new NormalityTestAction(this));
-        tools.add(new DescriptiveStatsAction(this));
+        tools.add(new DescriptiveStatsAction2(this));
 
         final int vkBackSpace = KeyEvent.VK_BACK_SPACE;
         final int vkDelete = KeyEvent.VK_DELETE;

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/DataEditor.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/DataEditor.java
@@ -646,7 +646,7 @@ public final class DataEditor extends JPanel implements KnowledgeEditable,
         tools.add(new PlotMatrixAction(this));
         tools.add(new QQPlotAction(this));
         tools.add(new NormalityTestAction(this));
-        tools.add(new DescriptiveStatsAction2(this));
+        tools.add(new DescriptiveStatsAction(this));
 
         final int vkBackSpace = KeyEvent.VK_BACK_SPACE;
         final int vkDelete = KeyEvent.VK_DELETE;

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/DescriptiveStatisticsJTable.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/DescriptiveStatisticsJTable.java
@@ -1,0 +1,166 @@
+///////////////////////////////////////////////////////////////////////////////
+// For information as to what this class does, see the Javadoc, below.       //
+// Copyright (C) 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005, 2006,       //
+// 2007, 2008, 2009, 2010, 2014, 2015, 2022 by Peter Spirtes, Richard        //
+// Scheines, Joseph Ramsey, and Clark Glymour.                               //
+//                                                                           //
+// This program is free software; you can redistribute it and/or modify      //
+// it under the terms of the GNU General Public License as published by      //
+// the Free Software Foundation; either version 2 of the License, or         //
+// (at your option) any later version.                                       //
+//                                                                           //
+// This program is distributed in the hope that it will be useful,           //
+// but WITHOUT ANY WARRANTY; without even the implied warranty of            //
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the             //
+// GNU General Public License for more details.                              //
+//                                                                           //
+// You should have received a copy of the GNU General Public License         //
+// along with this program; if not, write to the Free Software               //
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA //
+///////////////////////////////////////////////////////////////////////////////
+package edu.cmu.tetradapp.editor;
+
+import edu.cmu.tetrad.data.DataModel;
+import edu.cmu.tetrad.data.DataSet;
+import edu.cmu.tetrad.util.JOptionUtils;
+
+import javax.swing.*;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ListSelectionEvent;
+import javax.swing.event.TableColumnModelEvent;
+import javax.swing.event.TableColumnModelListener;
+import javax.swing.table.DefaultTableCellRenderer;
+import javax.swing.table.TableCellEditor;
+import javax.swing.table.TableColumnModel;
+import java.awt.*;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+
+/**
+ * Displays a DataSet object as a JTable.
+ *
+ * @author josephramsey
+ */
+public class DescriptiveStatisticsJTable extends JTable implements DataModelContainer,
+        PropertyChangeListener {
+
+    /**
+     * Constructor. Takes a DataSet as a model.
+     */
+    public DescriptiveStatisticsJTable(DataSet model) {
+        DescriptiveStatsModel dataModel = new DescriptiveStatsModel(model);
+        setModel(dataModel);
+        setAutoResizeMode(JTable.AUTO_RESIZE_OFF);
+//		System.out.println("dataModel: "+model.getColumnToTooltip());
+        int rowCount = this.dataModel.getRowCount();
+        int max = 0;
+
+        while (rowCount > 0) {
+            rowCount /= 10;
+            max++;
+        }
+
+        FontMetrics metrics = getFontMetrics(getFont());
+
+        getColumnModel().getColumn(0).setMaxWidth(60);
+        setRowHeight(metrics.getHeight() + 3);
+
+        setRowSelectionAllowed(true);
+        getColumnModel().setColumnSelectionAllowed(true);
+
+        for (int i = 0; i < getColumnModel().getColumnCount(); i++) {
+            final TableColumnModel columnModel1 = getColumnModel();
+            columnModel1.getColumn(i).setCellRenderer(new RightAlignRenderer());
+            setRowSelectionAllowed(true);
+//            addColumnSelectionInterval(i + 1, i + 1);
+        }
+
+        getColumnModel().addColumnModelListener(new TableColumnModelListener() {
+            public void columnAdded(TableColumnModelEvent e) {
+            }
+
+            public void columnRemoved(TableColumnModelEvent e) {
+            }
+
+            public void columnMoved(TableColumnModelEvent e) {
+            }
+
+            public void columnMarginChanged(ChangeEvent e) {
+            }
+
+            /**
+             * Sets the selection of columns in the model to what's in the
+             * display.
+             */
+            public void columnSelectionChanged(ListSelectionEvent e) {
+                if (e.getValueIsAdjusting()) {
+                    return;
+                }
+
+                ListSelectionModel selectionModel = (ListSelectionModel) e
+                        .getSource();
+                DataSet dataSet = getDataSet();
+                dataSet.clearSelection();
+
+                if (!getRowSelectionAllowed()) {
+                    for (int i = 0; i < dataSet.getNumColumns(); i++) {
+                        if (selectionModel.isSelectedIndex(i + 1)) {
+                            dataSet.setSelected(dataSet.getVariable(i), true);
+                        }
+                    }
+                }
+            }
+        });
+
+        setTransferHandler(new TabularDataTransferHandler());
+
+        addFocusListener(new FocusAdapter() {
+            public void focusLost(FocusEvent e) {
+                JTable table = (JTable) e.getSource();
+                TableCellEditor editor = table.getCellEditor();
+                if (editor != null) {
+                    editor.stopCellEditing();
+                }
+            }
+        });
+    }
+
+    public void setValueAt(Object aValue, int row, int column) {
+        try {
+            super.setValueAt(aValue, row, column);
+        } catch (Exception e) {
+            JOptionPane.showMessageDialog(JOptionUtils.centeringComp(), e
+                    .getMessage(), "Error", JOptionPane.WARNING_MESSAGE);
+        }
+    }
+
+    /**
+     * @return the underlying DataSet model.
+     */
+    public DataSet getDataSet() {
+        DescriptiveStatsModel tableModelTabularData = (DescriptiveStatsModel) getModel();
+        return tableModelTabularData.getDataSet();
+    }
+
+    public void setDataSet(DataSet data) {
+        TabularDataTable tableModelTabularData = (TabularDataTable) getModel();
+        tableModelTabularData.setDataSet(data);
+    }
+
+    public DataModel getDataModel() {
+        return getDataSet();
+    }
+
+    public void propertyChange(PropertyChangeEvent evt) {
+        firePropertyChange(evt.getPropertyName(), evt.getOldValue(), evt.getNewValue());
+    }
+
+    public class RightAlignRenderer extends DefaultTableCellRenderer {
+        public RightAlignRenderer() {
+            setHorizontalAlignment(JLabel.RIGHT);
+        }
+    }
+}
+

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/DescriptiveStatisticsJTable.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/DescriptiveStatisticsJTable.java
@@ -53,25 +53,20 @@ public class DescriptiveStatisticsJTable extends JTable implements DataModelCont
         DescriptiveStatsModel dataModel = new DescriptiveStatsModel(model);
         setModel(dataModel);
         setAutoResizeMode(JTable.AUTO_RESIZE_OFF);
-//		System.out.println("dataModel: "+model.getColumnToTooltip());
         int rowCount = this.dataModel.getRowCount();
-        int max = 0;
 
         while (rowCount > 0) {
             rowCount /= 10;
-            max++;
         }
 
         FontMetrics metrics = getFontMetrics(getFont());
-
-//        getColumnModel().getColumn(0).setMaxWidth(60);
         setRowHeight(metrics.getHeight() + 3);
 
         setRowSelectionAllowed(true);
         getColumnModel().setColumnSelectionAllowed(true);
 
         for (int i = 0; i < getColumnModel().getColumnCount(); i++) {
-            final TableColumnModel columnModel1 = getColumnModel();
+            TableColumnModel columnModel1 = getColumnModel();
 
             if (i == 0) {
                 columnModel1.getColumn(i).setCellRenderer(new LeftAlignRenderer());
@@ -80,7 +75,6 @@ public class DescriptiveStatisticsJTable extends JTable implements DataModelCont
             }
 
             setRowSelectionAllowed(true);
-//            addColumnSelectionInterval(i + 1, i + 1);
         }
 
         getColumnModel().addColumnModelListener(new TableColumnModelListener() {

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/DescriptiveStatisticsJTable.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/DescriptiveStatisticsJTable.java
@@ -163,13 +163,13 @@ public class DescriptiveStatisticsJTable extends JTable implements DataModelCont
         firePropertyChange(evt.getPropertyName(), evt.getOldValue(), evt.getNewValue());
     }
 
-    public class RightAlignRenderer extends DefaultTableCellRenderer {
+    public static class RightAlignRenderer extends DefaultTableCellRenderer {
         public RightAlignRenderer() {
             setHorizontalAlignment(JLabel.RIGHT);
         }
     }
 
-    public class LeftAlignRenderer extends DefaultTableCellRenderer {
+    public static class LeftAlignRenderer extends DefaultTableCellRenderer {
         public LeftAlignRenderer() {
             setHorizontalAlignment(JLabel.LEFT);
         }

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/DescriptiveStatisticsJTable.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/DescriptiveStatisticsJTable.java
@@ -64,7 +64,7 @@ public class DescriptiveStatisticsJTable extends JTable implements DataModelCont
 
         FontMetrics metrics = getFontMetrics(getFont());
 
-        getColumnModel().getColumn(0).setMaxWidth(60);
+//        getColumnModel().getColumn(0).setMaxWidth(60);
         setRowHeight(metrics.getHeight() + 3);
 
         setRowSelectionAllowed(true);
@@ -72,7 +72,13 @@ public class DescriptiveStatisticsJTable extends JTable implements DataModelCont
 
         for (int i = 0; i < getColumnModel().getColumnCount(); i++) {
             final TableColumnModel columnModel1 = getColumnModel();
-            columnModel1.getColumn(i).setCellRenderer(new RightAlignRenderer());
+
+            if (i == 0) {
+                columnModel1.getColumn(i).setCellRenderer(new LeftAlignRenderer());
+            } else {
+                columnModel1.getColumn(i).setCellRenderer(new RightAlignRenderer());
+            }
+
             setRowSelectionAllowed(true);
 //            addColumnSelectionInterval(i + 1, i + 1);
         }
@@ -160,6 +166,12 @@ public class DescriptiveStatisticsJTable extends JTable implements DataModelCont
     public class RightAlignRenderer extends DefaultTableCellRenderer {
         public RightAlignRenderer() {
             setHorizontalAlignment(JLabel.RIGHT);
+        }
+    }
+
+    public class LeftAlignRenderer extends DefaultTableCellRenderer {
+        public LeftAlignRenderer() {
+            setHorizontalAlignment(JLabel.LEFT);
         }
     }
 }

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/DescriptiveStatisticsTransferHandler.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/DescriptiveStatisticsTransferHandler.java
@@ -37,10 +37,10 @@ class DescriptiveStatisticsTransferHandler extends TransferHandler {
     /**
      * Create a Transferable to use as the source for a data transfer.
      *
-     * @param c The component holding the data to be transfered.  This argument
+     * @param c The component holding the data to be transferred.  This argument
      *          is provided to enable sharing of TransferHandlers by multiple
      *          components.
-     * @return The representation of the data to be transfered.
+     * @return The representation of the data to be transferred.
      */
     protected Transferable createTransferable(JComponent c) {
         if (c instanceof DescriptiveStatisticsJTable) {
@@ -49,10 +49,6 @@ class DescriptiveStatisticsTransferHandler extends TransferHandler {
             StringBuilder buf = new StringBuilder();
             final int[] selectedRows = tabularData.getSelectedRows();
             final int[] selectedColumns = tabularData.getSelectedColumns();
-
-
-//            JTableHeader header = tabularData.getTableHeader();
-//            header.
 
             buf.append("\t");
 

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/DescriptiveStatisticsTransferHandler.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/DescriptiveStatisticsTransferHandler.java
@@ -1,0 +1,85 @@
+///////////////////////////////////////////////////////////////////////////////
+// For information as to what this class does, see the Javadoc, below.       //
+// Copyright (C) 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005, 2006,       //
+// 2007, 2008, 2009, 2010, 2014, 2015, 2022 by Peter Spirtes, Richard        //
+// Scheines, Joseph Ramsey, and Clark Glymour.                               //
+//                                                                           //
+// This program is free software; you can redistribute it and/or modify      //
+// it under the terms of the GNU General Public License as published by      //
+// the Free Software Foundation; either version 2 of the License, or         //
+// (at your option) any later version.                                       //
+//                                                                           //
+// This program is distributed in the hope that it will be useful,           //
+// but WITHOUT ANY WARRANTY; without even the implied warranty of            //
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the             //
+// GNU General Public License for more details.                              //
+//                                                                           //
+// You should have received a copy of the GNU General Public License         //
+// along with this program; if not, write to the Free Software               //
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA //
+///////////////////////////////////////////////////////////////////////////////
+
+package edu.cmu.tetradapp.editor;
+
+import javax.swing.*;
+import java.awt.datatransfer.StringSelection;
+import java.awt.datatransfer.Transferable;
+
+/**
+ * Implements basic cut-and-paste operations for DataDisplay.
+ */
+class DescriptiveStatisticsTransferHandler extends TransferHandler {
+
+    public int getSourceActions(JComponent c) {
+        return TransferHandler.COPY_OR_MOVE;
+    }
+
+    /**
+     * Create a Transferable to use as the source for a data transfer.
+     *
+     * @param c The component holding the data to be transfered.  This argument
+     *          is provided to enable sharing of TransferHandlers by multiple
+     *          components.
+     * @return The representation of the data to be transfered.
+     */
+    protected Transferable createTransferable(JComponent c) {
+        if (c instanceof DescriptiveStatisticsJTable) {
+            DescriptiveStatisticsJTable tabularData = (DescriptiveStatisticsJTable) c;
+
+            StringBuilder buf = new StringBuilder();
+            final int[] selectedRows = tabularData.getSelectedRows();
+            final int[] selectedColumns = tabularData.getSelectedColumns();
+
+
+//            JTableHeader header = tabularData.getTableHeader();
+//            header.
+
+            buf.append("\t");
+
+            for (int j = 0; j < selectedColumns.length - 1; j++) {
+                buf.append(tabularData.getModel().getColumnName(selectedColumns[j])).append("\t");
+            }
+
+            buf.append(tabularData.getModel().getColumnName(selectedColumns[selectedColumns.length - 1]));
+            buf.append("\n");
+
+            for (int i = 0; i < selectedRows.length; i++) {
+                buf.append(tabularData.getValueAt(selectedRows[i], 0)).append("\t");
+
+                for (int j = 0; j < selectedColumns.length - 1; j++) {
+                    buf.append(tabularData.getValueAt(selectedRows[i], selectedColumns[j])).append("\t");
+                }
+
+                buf.append(tabularData.getValueAt(selectedRows[i], selectedColumns[selectedColumns.length - 1]));
+                buf.append("\n");
+            }
+
+            return new StringSelection(buf.toString());
+        }
+
+        return null;
+    }
+}
+
+
+

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/DescriptiveStatisticsTransferHandler.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/DescriptiveStatisticsTransferHandler.java
@@ -63,14 +63,14 @@ class DescriptiveStatisticsTransferHandler extends TransferHandler {
             buf.append(tabularData.getModel().getColumnName(selectedColumns[selectedColumns.length - 1]));
             buf.append("\n");
 
-            for (int i = 0; i < selectedRows.length; i++) {
-                buf.append(tabularData.getValueAt(selectedRows[i], 0)).append("\t");
+            for (int selectedRow : selectedRows) {
+                buf.append(tabularData.getValueAt(selectedRow, 0)).append("\t");
 
                 for (int j = 0; j < selectedColumns.length - 1; j++) {
-                    buf.append(tabularData.getValueAt(selectedRows[i], selectedColumns[j])).append("\t");
+                    buf.append(tabularData.getValueAt(selectedRow, selectedColumns[j])).append("\t");
                 }
 
-                buf.append(tabularData.getValueAt(selectedRows[i], selectedColumns[selectedColumns.length - 1]));
+                buf.append(tabularData.getValueAt(selectedRow, selectedColumns[selectedColumns.length - 1]));
                 buf.append("\n");
             }
 

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/DescriptiveStats.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/DescriptiveStats.java
@@ -136,7 +136,7 @@ class DescriptiveStats {
     /*
         Returns the median in index 0, but also returns the min and max in 1 and 2 respectively.
      */
-    private static double[] median(double[] data) {
+    public static double[] median(double[] data) {
         Arrays.sort(data);
 
         double[] result = new double[3];
@@ -156,7 +156,7 @@ class DescriptiveStats {
         return result;
     }
 
-    private static double standardErrorMean(double stdDev, double sampleSize) {
+    public static double standardErrorMean(double stdDev, double sampleSize) {
         return stdDev / (FastMath.sqrt(sampleSize));
     }
 
@@ -166,7 +166,7 @@ class DescriptiveStats {
      * @return [0] -&gt; mean, [1] -&gt; standard deviation, [2] -&gt; variance
      */
 
-    private static double[] normalParams(double[] data) {
+    public static double[] normalParams(double[] data) {
         double mean = 0.0;
         double sd = 0.0;
 

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/DescriptiveStatsAction.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/DescriptiveStatsAction.java
@@ -43,14 +43,14 @@ import java.util.List;
 class DescriptiveStatsAction extends AbstractAction {
 
     /**
-     * The data edtitor that action is attached to.
+     * The data editor that action is attached to.
      */
     private final DataEditor dataEditor;
 
 
     /**
      * Constructs the <code>DescriptiveStatsAction</code> given the <code>DataEditor</code>
-     * that its attached to.
+     * that it's attached to.
      */
     public DescriptiveStatsAction(DataEditor editor) {
         super("Descriptive Statistics...");
@@ -88,6 +88,7 @@ class DescriptiveStatsAction extends AbstractAction {
         DataSet dataSet = (DataSet) this.dataEditor.getSelectedDataModel();
 
         String coonstantColumnsString = "Constant Columns: ";
+        assert dataSet != null;
         java.util.List<Node> constantColumns = DataUtils.getConstantColumns(dataSet);
         coonstantColumnsString += constantColumns.isEmpty() ? "None" : constantColumns.toString();
 
@@ -135,18 +136,6 @@ class DescriptiveStatsAction extends AbstractAction {
 
         return box;
     }
-
-//    private JTable getSelectedJTable() {
-//        Object display = tabbedPane().getSelectedComponent();
-//
-//        if (display instanceof DataDisplay) {
-//            return ((DataDisplay) display).getDataDisplayJTable();
-//        } else if (display instanceof CovMatrixDisplay) {
-//            return ((CovMatrixDisplay) display).getCovMatrixJTable();
-//        }
-//
-//        return null;
-//    }
 
     private JFrame findOwner() {
         return (JFrame) SwingUtilities.getAncestorOfClass(

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/DescriptiveStatsAction2.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/DescriptiveStatsAction2.java
@@ -1,0 +1,131 @@
+///////////////////////////////////////////////////////////////////////////////
+// For information as to what this class does, see the Javadoc, below.       //
+// Copyright (C) 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005, 2006,       //
+// 2007, 2008, 2009, 2010, 2014, 2015, 2022 by Peter Spirtes, Richard        //
+// Scheines, Joseph Ramsey, and Clark Glymour.                               //
+//                                                                           //
+// This program is free software; you can redistribute it and/or modify      //
+// it under the terms of the GNU General Public License as published by      //
+// the Free Software Foundation; either version 2 of the License, or         //
+// (at your option) any later version.                                       //
+//                                                                           //
+// This program is distributed in the hope that it will be useful,           //
+// but WITHOUT ANY WARRANTY; without even the implied warranty of            //
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the             //
+// GNU General Public License for more details.                              //
+//                                                                           //
+// You should have received a copy of the GNU General Public License         //
+// along with this program; if not, write to the Free Software               //
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA //
+///////////////////////////////////////////////////////////////////////////////
+
+package edu.cmu.tetradapp.editor;
+
+import edu.cmu.tetrad.data.DataSet;
+import edu.cmu.tetradapp.util.DesktopController;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+
+/**
+ * Displays descriptive statistics for a random variable.
+ *
+ * @author Michael Freenor
+ */
+
+class DescriptiveStatsAction2 extends AbstractAction {
+
+
+    /**
+     * The data edtitor that action is attached to.
+     */
+    private final DataEditor dataEditor;
+
+
+    /**
+     * Constructs the <code>DescriptiveStatsAction</code> given the <code>DataEditor</code>
+     * that its attached to.
+     */
+    public DescriptiveStatsAction2(DataEditor editor) {
+        super("Descriptive Statistics...");
+        this.dataEditor = editor;
+    }
+
+    public void actionPerformed(ActionEvent e) {
+        if (!(this.dataEditor.getSelectedDataModel() instanceof DataSet)) {
+            JOptionPane.showMessageDialog(findOwner(), "Need a tabular dataset to generate descriptive statistics.");
+            return;
+        }
+
+        DataSet dataSet = (DataSet) this.dataEditor.getSelectedDataModel();
+        if (dataSet == null || dataSet.getNumColumns() == 0) {
+            JOptionPane.showMessageDialog(findOwner(), "Cannot generate descriptive statistics on an empty data set.");
+            return;
+        }
+
+        JPanel panel = createDescriptiveStatsDialog();
+
+        EditorWindow window = new EditorWindow(panel,
+                "Descriptive Statistics", "Close", false, this.dataEditor);
+        DesktopController.getInstance().addEditorWindow(window, JLayeredPane.PALETTE_LAYER);
+        window.setVisible(true);
+
+    }
+
+    //============================== Private methods ============================//
+
+    /**
+     * Creates a dialog that is showing the histogram for the given node (if null
+     * one is selected for you)
+     */
+    private JPanel createDescriptiveStatsDialog() {
+        DataSet dataSet = (DataSet) this.dataEditor.getSelectedDataModel();
+
+        DescriptiveStatisticsJTable jTable = new DescriptiveStatisticsJTable(dataSet);
+        jTable.setTransferHandler(new DescriptiveStatisticsTransferHandler());
+
+        JMenuBar bar = new JMenuBar();
+        JMenuItem copyCells = new JMenuItem("Copy Cells");
+        copyCells.setAccelerator(
+                KeyStroke.getKeyStroke(KeyEvent.VK_C, InputEvent.CTRL_DOWN_MASK));
+        copyCells.addActionListener(e -> {
+            Action copyAction = TransferHandler.getCopyAction();
+            ActionEvent actionEvent = new ActionEvent(jTable,
+                    ActionEvent.ACTION_PERFORMED, "copy");
+            copyAction.actionPerformed(actionEvent);
+        });
+
+        JMenu editMenu = new JMenu("Edit");
+        editMenu.add(copyCells);
+        bar.add(editMenu);
+
+        JPanel panel = new JPanel();
+        panel.setLayout(new BorderLayout());
+        panel.add(bar, BorderLayout.NORTH);
+        panel.add(new JScrollPane(jTable), BorderLayout.CENTER);
+
+        return panel;
+    }
+
+//    private JTable getSelectedJTable() {
+//        Object display = tabbedPane().getSelectedComponent();
+//
+//        if (display instanceof DataDisplay) {
+//            return ((DataDisplay) display).getDataDisplayJTable();
+//        } else if (display instanceof CovMatrixDisplay) {
+//            return ((CovMatrixDisplay) display).getCovMatrixJTable();
+//        }
+//
+//        return null;
+//    }
+
+    private JFrame findOwner() {
+        return (JFrame) SwingUtilities.getAncestorOfClass(
+                JFrame.class, this.dataEditor);
+    }
+}
+
+

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/DescriptiveStatsModel.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/DescriptiveStatsModel.java
@@ -115,7 +115,7 @@ class DescriptiveStatsModel extends AbstractTableModel {
         if (continuous) {
             double[] median = DescriptiveStats.median(data);
 
-            names.add("SE Mean");
+            names.add("SE_Mean");
             stats.add(StatUtils.skewness(data));
 
             names.add("Median");
@@ -134,13 +134,13 @@ class DescriptiveStatsModel extends AbstractTableModel {
             double a2Star = andersonDarlingTest.getASquaredStar();
             double adP = andersonDarlingTest.getP();
 
-            names.add("a2");
+            names.add("A2");
             stats.add(a2);
 
-            names.add("a2*");
+            names.add("A2*");
             stats.add(a2Star);
 
-            names.add("ad-p");
+            names.add("AD-p");
             stats.add(adP);
 
             String[] pass = new String[5];
@@ -151,19 +151,19 @@ class DescriptiveStatsModel extends AbstractTableModel {
             if (ksResults[0] < ksResults[4]) pass[3] = "ACCEPT";
             if (ksResults[0] < ksResults[5]) pass[4] = "ACCEPT";
 
-            names.add("ks.2");
+            names.add("KS.2");
             stats.add(pass[0]);
 
-            names.add("ks.15");
+            names.add("KS.15");
             stats.add(pass[2]);
 
-            names.add("ks.1]");
+            names.add("KS.1");
             stats.add(pass[2]);
 
-            names.add("ks.05");
+            names.add("KS.05");
             stats.add(pass[3]);
 
-            names.add("ks.01");
+            names.add("KS.01");
             stats.add(pass[4]);
         }
 

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/DescriptiveStatsModel.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/DescriptiveStatsModel.java
@@ -1,0 +1,198 @@
+///////////////////////////////////////////////////////////////////////////////
+// For information as to what this class does, see the Javadoc, below.       //
+// Copyright (C) 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005, 2006,       //
+// 2007, 2008, 2009, 2010, 2014, 2015, 2022 by Peter Spirtes, Richard        //
+// Scheines, Joseph Ramsey, and Clark Glymour.                               //
+//                                                                           //
+// This program is free software; you can redistribute it and/or modify      //
+// it under the terms of the GNU General Public License as published by      //
+// the Free Software Foundation; either version 2 of the License, or         //
+// (at your option) any later version.                                       //
+//                                                                           //
+// This program is distributed in the hope that it will be useful,           //
+// but WITHOUT ANY WARRANTY; without even the implied warranty of            //
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the             //
+// GNU General Public License for more details.                              //
+//                                                                           //
+// You should have received a copy of the GNU General Public License         //
+// along with this program; if not, write to the Free Software               //
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA //
+///////////////////////////////////////////////////////////////////////////////
+package edu.cmu.tetradapp.editor;
+
+import edu.cmu.tetrad.data.ContinuousVariable;
+import edu.cmu.tetrad.data.DataSet;
+import edu.cmu.tetrad.data.DiscreteVariable;
+import edu.cmu.tetrad.graph.Node;
+import edu.cmu.tetrad.util.NumberFormatUtil;
+import edu.cmu.tetrad.util.StatUtils;
+
+import javax.swing.table.AbstractTableModel;
+import java.text.NumberFormat;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A table for descriptive statistics for each variable in a dataset.
+ *
+ * @author josephramsey
+ */
+class DescriptiveStatsModel extends AbstractTableModel {
+    private static final long serialVersionUID = 23L;
+    private final List<Node> vars;
+    private final List<Ret> stats;
+    private DataSet dataSet;
+
+    /**
+     * Constructs a new DisplayTableModel to wrap the given dataSet.
+     *
+     * @param dataSet the dataSet.
+     */
+    public DescriptiveStatsModel(DataSet dataSet) {
+        this.dataSet = dataSet;
+        this.vars = new ArrayList<>(dataSet.getVariables());
+        Collections.sort(vars);
+        this.stats = new ArrayList<>();
+
+        for (Node n : vars) {
+            this.stats.add(generateDescriptiveStats(dataSet, n));
+        }
+    }
+
+    /**
+     * Note that returning null here has two effects. First, it
+     */
+    public String getColumnName(int col) {
+        if (col == 0) return  "Variable";
+        return stats.get(0).names.get(col - 1);
+    }
+
+    /**
+     * @return the number of rows in the wrapper table model. Guarantees that
+     * this number will be at least 100.
+     */
+    public int getRowCount() {
+        return vars.size();
+    }
+
+    /**
+     * @return the number of columns in the wrapper table model. Guarantees that
+     * this number will be at least 30.
+     */
+    public int getColumnCount() {
+        return stats.get(0).stats.size() + 1;
+    }
+
+    public Object getValueAt(int row, int col) {
+        if (col == 0) return vars.get(row).getName();
+        else {
+            final Number number = stats.get(row).stats.get(col - 1);
+            NumberFormat nf = NumberFormatUtil.getInstance().getNumberFormat();
+
+            if (number instanceof Double) {
+                return nf.format(number);
+            } else {
+                return number;
+            }
+        }
+    }
+
+    public DataSet getDataSet() {
+        return dataSet;
+    }
+
+    private static class Ret {
+        List<String> names;
+        List<Number> stats;
+    }
+
+    public static Ret generateDescriptiveStats(DataSet dataSet, Node variable) {
+        List<String> names = new ArrayList<>();
+        List<Number> stats = new ArrayList<>();
+
+        NumberFormat nf = NumberFormatUtil.getInstance().getNumberFormat();
+
+        int col = dataSet.getColumn(variable);
+
+        // Extract the data.
+        double[] data = new double[dataSet.getNumRows()];
+        boolean continuous = false;
+
+        if (variable instanceof ContinuousVariable) {
+            continuous = true;
+
+            for (int i = 0; i < dataSet.getNumRows(); i++) {
+                data[i] = dataSet.getDouble(i, col);
+            }
+        } else {
+            DiscreteVariable var = (DiscreteVariable) variable;
+
+            for (int i = 0; i < dataSet.getNumRows(); i++) {
+                String category = var.getCategory(dataSet.getInt(i, col));
+                int value = Integer.parseInt(category);
+                data[i] = value;
+            }
+        }
+
+        double[] normalValues = DescriptiveStats.normalParams(data);
+
+        names.add("N");
+        stats.add(dataSet.getNumRows());
+
+        names.add("Mean");
+        stats.add(normalValues[0]);
+
+        names.add("StdDev");
+        stats.add(normalValues[1]);
+
+        names.add("Variance");
+        stats.add(normalValues[2]);
+
+        names.add("Skewness");
+        stats.add(StatUtils.skewness(data));
+
+        names.add("Kurtosis");
+        stats.add(StatUtils.kurtosis(data));
+
+        names.add("Skewness");
+        stats.add(StatUtils.skewness(data));
+
+
+
+        if (continuous) {
+            double[] median = DescriptiveStats.median(data);
+
+            names.add("SE Mean");
+            stats.add(StatUtils.skewness(data));
+
+            names.add("Median");
+            stats.add(median[0]);
+
+            names.add("Minimum");
+            stats.add(median[1]);
+
+            names.add("Maximum");
+            stats.add(median[2]);
+        }
+
+//        table.setToken(rowindex, 0, "Constant Columns:");
+//        java.util.List<Node> constantColumns = DataUtils.getConstantColumns(dataSet);
+//        table.setToken(rowindex++, 1, constantColumns.isEmpty() ? "None" : constantColumns.toString());
+//
+//        table.setToken(rowindex, 0, "Example Nonsingular (2 - 3 vars):");
+//
+//        CovarianceMatrix covarianceMatrix = new CovarianceMatrix(dataSet);
+//        List<Node> exampleNonsingular = DataUtils.getExampleNonsingular(covarianceMatrix, 3);
+//        table.setToken(rowindex, 1, exampleNonsingular == null ? "None" : exampleNonsingular.toString());
+
+//        b.append(table);
+
+        Ret ret = new Ret();
+        ret.names = names;
+        ret.stats = stats;
+
+        return ret;
+    }
+
+}

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/EditorWindow.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/EditorWindow.java
@@ -39,7 +39,7 @@ import java.awt.event.ActionListener;
 public class EditorWindow extends JInternalFrame
         implements EditorWindowIndirectRef, Comparable {
 
-    private JPanel editor;
+    private JComponent editor;
 
     /**
      * Set to true if the dialog was canceled.
@@ -64,7 +64,7 @@ public class EditorWindow extends JInternalFrame
     /**
      * Pops a new editor window up from a dialog.
      */
-    public EditorWindow(JPanel editor, String title, String buttonName,
+    public EditorWindow(JComponent editor, String title, String buttonName,
                         boolean cancellable, Component centeringComp) {
         super(title, true, true, true, false);
 
@@ -90,7 +90,7 @@ public class EditorWindow extends JInternalFrame
     /**
      * Constructs the dialog.
      */
-    private void doSetup(JPanel editor, boolean cancellable) {
+    private void doSetup(JComponent editor, boolean cancellable) {
         this.editor = editor;
         this.okButton = null;
 
@@ -126,10 +126,10 @@ public class EditorWindow extends JInternalFrame
         b0.add(editor);
         b0.add(b);
 
-        Dimension screensize = Toolkit.getDefaultToolkit().getScreenSize();
+        Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
 
-        int width = FastMath.min(b0.getPreferredSize().width + 50, screensize.width);
-        int height = FastMath.min(b0.getPreferredSize().height + 50, screensize.height - 100);
+        int width = FastMath.min(b0.getPreferredSize().width + 50, screenSize.width);
+        int height = FastMath.min(b0.getPreferredSize().height + 50, screenSize.height - 100);
 
         if (!(editor instanceof DoNotScroll) && (b0.getPreferredSize().width > width || b0.getPreferredSize().height > height)) {
             JScrollPane scroll = new JScrollPane(b0);

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/TabularDataJTable.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/TabularDataJTable.java
@@ -87,6 +87,7 @@ public class TabularDataJTable extends JTable implements DataModelContainer,
             rowCount /= 10;
             max++;
         }
+
         // add cell renderer for columns 2-7
         // int vColIndex = 2;
         // TableColumn col = this.getColumnModel().getColumn(vColIndex);

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/continuous/dag/DirectLingam.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/continuous/dag/DirectLingam.java
@@ -69,7 +69,7 @@ public class DirectLingam implements Algorithm, UsesScoreWrapper, ReturnsBootstr
 
             search.setParameters(parameters);
             search.setVerbose(parameters.getBoolean(Params.VERBOSE));
-            this.bootstrapGraphs = search.getGraphs();
+            if (parameters.getBoolean(Params.SAVE_BOOTSTRAP_GRAPHS)) this.bootstrapGraphs = search.getGraphs();
             return search.search();
         }
     }

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/continuous/dag/IcaLingD.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/continuous/dag/IcaLingD.java
@@ -80,7 +80,7 @@ public class IcaLingD implements Algorithm, ReturnsBootstrapGraphs {
 
             search.setParameters(parameters);
             search.setVerbose(parameters.getBoolean(Params.VERBOSE));
-            this.bootstrapGraphs = search.getGraphs();
+            if (parameters.getBoolean(Params.SAVE_BOOTSTRAP_GRAPHS)) this.bootstrapGraphs = search.getGraphs();
             return search.search();
         }
     }

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/continuous/dag/IcaLingam.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/continuous/dag/IcaLingam.java
@@ -68,7 +68,7 @@ public class IcaLingam implements Algorithm, ReturnsBootstrapGraphs {
 
             search.setParameters(parameters);
             search.setVerbose(parameters.getBoolean(Params.VERBOSE));
-            this.bootstrapGraphs = search.getGraphs();
+            if (parameters.getBoolean(Params.SAVE_BOOTSTRAP_GRAPHS)) this.bootstrapGraphs = search.getGraphs();
             return search.search();
         }
     }

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/cpdag/Boss.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/cpdag/Boss.java
@@ -87,7 +87,7 @@ public class Boss implements Algorithm, UsesScoreWrapper, HasKnowledge,
             search.setParameters(parameters);
             search.setVerbose(parameters.getBoolean(Params.VERBOSE));
             Graph graph = search.search();
-            this.bootstrapGraphs = search.getGraphs();
+            if (parameters.getBoolean(Params.SAVE_BOOTSTRAP_GRAPHS)) this.bootstrapGraphs = search.getGraphs();
             return graph;
         }
     }

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/cpdag/Cpc.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/cpdag/Cpc.java
@@ -118,7 +118,7 @@ public class Cpc implements Algorithm, HasKnowledge, TakesIndependenceWrapper,
             search.setParameters(parameters);
             search.setVerbose(parameters.getBoolean(Params.VERBOSE));
             Graph graph = search.search();
-            this.bootstrapGraphs = search.getGraphs();
+            if (parameters.getBoolean(Params.SAVE_BOOTSTRAP_GRAPHS)) this.bootstrapGraphs = search.getGraphs();
             return graph;
         }
     }

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/cpdag/Fas.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/cpdag/Fas.java
@@ -95,7 +95,7 @@ public class Fas implements Algorithm, HasKnowledge, TakesIndependenceWrapper,
             search.setParameters(parameters);
             search.setVerbose(parameters.getBoolean(Params.VERBOSE));
             Graph graph = search.search();
-            this.bootstrapGraphs = search.getGraphs();
+            if (parameters.getBoolean(Params.SAVE_BOOTSTRAP_GRAPHS)) this.bootstrapGraphs = search.getGraphs();
             return graph;
         }
     }

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/cpdag/Fges.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/cpdag/Fges.java
@@ -113,9 +113,9 @@ public class Fges implements Algorithm, HasKnowledge, UsesScoreWrapper, TakesExt
             search.setKnowledge(this.knowledge);
             search.setParameters(parameters);
             search.setVerbose(parameters.getBoolean(Params.VERBOSE));
-            this.bootstrapGraphs = search.getGraphs();
+            if (parameters.getBoolean(Params.SAVE_BOOTSTRAP_GRAPHS)) this.bootstrapGraphs = search.getGraphs();
             Graph graph = search.search();
-            this.bootstrapGraphs = search.getGraphs();
+            if (parameters.getBoolean(Params.SAVE_BOOTSTRAP_GRAPHS)) this.bootstrapGraphs = search.getGraphs();
             return graph;
         }
     }

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/cpdag/FgesMb.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/cpdag/FgesMb.java
@@ -81,7 +81,7 @@ public class FgesMb implements Algorithm, HasKnowledge, UsesScoreWrapper,
             search.setParameters(parameters);
             search.setVerbose(parameters.getBoolean(Params.VERBOSE));
             Graph graph = search.search();
-            this.bootstrapGraphs = search.getGraphs();
+            if (parameters.getBoolean(Params.SAVE_BOOTSTRAP_GRAPHS)) this.bootstrapGraphs = search.getGraphs();
             return graph;
         }
     }

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/cpdag/FgesMeasurement.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/cpdag/FgesMeasurement.java
@@ -78,7 +78,7 @@ public class FgesMeasurement implements Algorithm, HasKnowledge, ReturnsBootstra
             search.setParameters(parameters);
             search.setVerbose(parameters.getBoolean(Params.VERBOSE));
             Graph graph = search.search();
-            this.bootstrapGraphs = search.getGraphs();
+            if (parameters.getBoolean(Params.SAVE_BOOTSTRAP_GRAPHS)) this.bootstrapGraphs = search.getGraphs();
             return graph;
         }
     }

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/cpdag/GesMe.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/cpdag/GesMe.java
@@ -181,7 +181,7 @@ public class GesMe implements Algorithm, ReturnsBootstrapGraphs {
             search.setParameters(parameters);
             search.setVerbose(parameters.getBoolean(Params.VERBOSE));
             Graph graph = search.search();
-            this.bootstrapGraphs = search.getGraphs();
+            if (parameters.getBoolean(Params.SAVE_BOOTSTRAP_GRAPHS)) this.bootstrapGraphs = search.getGraphs();
             return graph;
         }
     }

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/cpdag/Grasp.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/cpdag/Grasp.java
@@ -99,7 +99,7 @@ public class Grasp implements Algorithm, UsesScoreWrapper, TakesIndependenceWrap
             search.setParameters(parameters);
             search.setVerbose(parameters.getBoolean(Params.VERBOSE));
             Graph graph = search.search();
-            this.bootstrapGraphs = search.getGraphs();
+            if (parameters.getBoolean(Params.SAVE_BOOTSTRAP_GRAPHS)) this.bootstrapGraphs = search.getGraphs();
             return graph;
         }
     }

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/cpdag/Pc.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/cpdag/Pc.java
@@ -117,7 +117,7 @@ public class Pc implements Algorithm, HasKnowledge, TakesIndependenceWrapper,
             search.setParameters(parameters);
             search.setVerbose(parameters.getBoolean(Params.VERBOSE));
             Graph graph = search.search();
-            this.bootstrapGraphs = search.getGraphs();
+            if (parameters.getBoolean(Params.SAVE_BOOTSTRAP_GRAPHS)) this.bootstrapGraphs = search.getGraphs();
             return graph;
         }
     }

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/cpdag/PcMb.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/cpdag/PcMb.java
@@ -72,7 +72,7 @@ public class PcMb implements Algorithm, HasKnowledge, TakesIndependenceWrapper,
             search.setParameters(parameters);
             search.setVerbose(parameters.getBoolean(Params.VERBOSE));
             Graph graph = search.search();
-            this.bootstrapGraphs = search.getGraphs();
+            if (parameters.getBoolean(Params.SAVE_BOOTSTRAP_GRAPHS)) this.bootstrapGraphs = search.getGraphs();
             return graph;
         }
     }

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/cpdag/Pcd.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/cpdag/Pcd.java
@@ -64,7 +64,7 @@ public class Pcd implements Algorithm, HasKnowledge, ReturnsBootstrapGraphs {
             search.setParameters(parameters);
             search.setVerbose(parameters.getBoolean(Params.VERBOSE));
             Graph graph = search.search();
-            this.bootstrapGraphs = search.getGraphs();
+            if (parameters.getBoolean(Params.SAVE_BOOTSTRAP_GRAPHS)) this.bootstrapGraphs = search.getGraphs();
             return graph;
         }
     }

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/cpdag/Sp.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/cpdag/Sp.java
@@ -83,7 +83,7 @@ public class Sp implements Algorithm, UsesScoreWrapper, HasKnowledge, ReturnsBoo
             search.setParameters(parameters);
             search.setVerbose(parameters.getBoolean(Params.VERBOSE));
             Graph graph = search.search();
-            this.bootstrapGraphs = search.getGraphs();
+            if (parameters.getBoolean(Params.SAVE_BOOTSTRAP_GRAPHS)) this.bootstrapGraphs = search.getGraphs();
             return graph;
         }
     }

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/pag/Bfci.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/pag/Bfci.java
@@ -99,7 +99,7 @@ public class Bfci implements Algorithm, UsesScoreWrapper,
             search.setParameters(parameters);
             search.setVerbose(parameters.getBoolean(Params.VERBOSE));
             Graph graph = search.search();
-            this.bootstrapGraphs = search.getGraphs();
+            if (parameters.getBoolean(Params.SAVE_BOOTSTRAP_GRAPHS)) this.bootstrapGraphs = search.getGraphs();
             return graph;
         }
     }

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/pag/Ccd.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/pag/Ccd.java
@@ -61,7 +61,7 @@ public class Ccd implements Algorithm, TakesIndependenceWrapper, ReturnsBootstra
             search.setParameters(parameters);
             search.setVerbose(parameters.getBoolean(Params.VERBOSE));
             Graph graph = search.search();
-            this.bootstrapGraphs = search.getGraphs();
+            if (parameters.getBoolean(Params.SAVE_BOOTSTRAP_GRAPHS)) this.bootstrapGraphs = search.getGraphs();
             return graph;
         }
     }

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/pag/Cfci.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/pag/Cfci.java
@@ -59,7 +59,7 @@ public class Cfci implements Algorithm, HasKnowledge, ReturnsBootstrapGraphs {
             search.setParameters(parameters);
             search.setVerbose(parameters.getBoolean(Params.VERBOSE));
             Graph graph = search.search();
-            this.bootstrapGraphs = search.getGraphs();
+            if (parameters.getBoolean(Params.SAVE_BOOTSTRAP_GRAPHS)) this.bootstrapGraphs = search.getGraphs();
             return graph;
         }
     }

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/pag/Fci.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/pag/Fci.java
@@ -104,7 +104,7 @@ public class Fci implements Algorithm, HasKnowledge, TakesIndependenceWrapper,
             search.setParameters(parameters);
             search.setVerbose(parameters.getBoolean(Params.VERBOSE));
             Graph graph = search.search();
-            this.bootstrapGraphs = search.getGraphs();
+            if (parameters.getBoolean(Params.SAVE_BOOTSTRAP_GRAPHS)) this.bootstrapGraphs = search.getGraphs();
             return graph;
         }
     }

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/pag/FciMax.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/pag/FciMax.java
@@ -102,7 +102,7 @@ public class FciMax implements Algorithm, HasKnowledge, TakesIndependenceWrapper
             search.setParameters(parameters);
             search.setVerbose(parameters.getBoolean(Params.VERBOSE));
             Graph graph = search.search();
-            this.bootstrapGraphs = search.getGraphs();
+            if (parameters.getBoolean(Params.SAVE_BOOTSTRAP_GRAPHS)) this.bootstrapGraphs = search.getGraphs();
             return graph;
         }
     }

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/pag/Gfci.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/pag/Gfci.java
@@ -95,7 +95,7 @@ public class Gfci implements Algorithm, HasKnowledge, UsesScoreWrapper, TakesInd
             search.setParameters(parameters);
             search.setVerbose(parameters.getBoolean(Params.VERBOSE));
             Graph graph = search.search();
-            this.bootstrapGraphs = search.getGraphs();
+            if (parameters.getBoolean(Params.SAVE_BOOTSTRAP_GRAPHS)) this.bootstrapGraphs = search.getGraphs();
             return graph;
         }
     }

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/pag/GraspFci.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/pag/GraspFci.java
@@ -112,7 +112,7 @@ public class GraspFci implements Algorithm, UsesScoreWrapper, TakesIndependenceW
             search.setParameters(parameters);
             search.setVerbose(parameters.getBoolean(Params.VERBOSE));
             Graph graph = search.search();
-            this.bootstrapGraphs = search.getGraphs();
+            if (parameters.getBoolean(Params.SAVE_BOOTSTRAP_GRAPHS)) this.bootstrapGraphs = search.getGraphs();
             return graph;
         }
     }

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/pag/Rfci.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/pag/Rfci.java
@@ -77,7 +77,7 @@ public class Rfci implements Algorithm, HasKnowledge, TakesIndependenceWrapper, 
             search.setParameters(parameters);
             search.setVerbose(parameters.getBoolean(Params.VERBOSE));
             Graph graph = search.search();
-            this.bootstrapGraphs = search.getGraphs();
+            if (parameters.getBoolean(Params.SAVE_BOOTSTRAP_GRAPHS)) this.bootstrapGraphs = search.getGraphs();
             return graph;
         }
     }

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/pag/SpFci.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/pag/SpFci.java
@@ -84,7 +84,7 @@ public class SpFci implements Algorithm, UsesScoreWrapper, TakesIndependenceWrap
             search.setParameters(parameters);
             search.setVerbose(parameters.getBoolean(Params.VERBOSE));
             Graph graph = search.search();
-            this.bootstrapGraphs = search.getGraphs();
+            if (parameters.getBoolean(Params.SAVE_BOOTSTRAP_GRAPHS)) this.bootstrapGraphs = search.getGraphs();
             return graph;
         }
     }

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/pag/SvarFci.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/pag/SvarFci.java
@@ -82,7 +82,7 @@ public class SvarFci implements Algorithm, HasKnowledge, TakesIndependenceWrappe
             search.setParameters(parameters);
             search.setVerbose(parameters.getBoolean(Params.VERBOSE));
             Graph graph = search.search();
-            this.bootstrapGraphs = search.getGraphs();
+            if (parameters.getBoolean(Params.SAVE_BOOTSTRAP_GRAPHS)) this.bootstrapGraphs = search.getGraphs();
             return graph;
         }
     }

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/pag/SvarGfci.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/pag/SvarGfci.java
@@ -88,7 +88,7 @@ public class SvarGfci implements Algorithm, HasKnowledge, TakesIndependenceWrapp
             search.setParameters(parameters);
             search.setVerbose(parameters.getBoolean(Params.VERBOSE));
             Graph graph = search.search();
-            this.bootstrapGraphs = search.getGraphs();
+            if (parameters.getBoolean(Params.SAVE_BOOTSTRAP_GRAPHS)) this.bootstrapGraphs = search.getGraphs();
             return graph;
         }
     }

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/util/Params.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/util/Params.java
@@ -242,6 +242,7 @@ public final class Params {
     public static final String SEED = "seed";
     public static final String SIGNIFICANCE_CHECKED = "significanceChecked";
     public static final String PROB_REMOVE_COLUMN = "probRemoveColumn";
+    public static final String SAVE_BOOTSTRAP_GRAPHS = "saveBootstrapGraphs";
 
     // All parameters that are found in HTML manual documentation
     private static final Set<String> ALL_PARAMS_IN_HTML_MANUAL = new HashSet<>(Arrays.asList(
@@ -287,6 +288,7 @@ public final class Params {
             Params.PERCENT_RESAMPLE_SIZE,
 //            Params.RESAMPLING_ENSEMBLE,
             Params.RESAMPLING_WITH_REPLACEMENT,
+            Params.SAVE_BOOTSTRAP_GRAPHS,
             Params.SEED
     ));
 


### PR DESCRIPTION
For Markov checker, added an "all sets" option that shoudl work with #vars <= 12. If you try it with more variables than that you get a warning. Added a new Descriptive Stats menu item to the Data Editor Tools menu that puts all fo the stats into a table and allows you to copy selections from the table to be pasted into a text file or Excel. Included the lsit of constant columns and example of a 2-3 variable singular column set, if these exist, at the bottom of the tool.

Also, added a parameter, saveBootstrapGraphs, default to false. If this parameter is set to true, individual bootstrapped graphs will be saved.