### PR TITLE
Added a feature to copy the selected dataset from a data box with multiple data models into a separate box.

### DIFF
--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/SplitCasesParamsEditor.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/SplitCasesParamsEditor.java
@@ -133,7 +133,7 @@ public class SplitCasesParamsEditor extends JPanel implements ParameterEditor {
 
         splitEditorPanel = new JPanel();
         splitEditorPanel.setLayout(new BorderLayout());
-        this.setNumSplits(params.getInt("numSplits", 3));
+        this.setNumSplits(params.getInt("numSplits", 2));
 
         JRadioButton shuffleButton = new JRadioButton("Shuffled order");
         JRadioButton noShuffleButton = new JRadioButton("Original order");

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/model/SelectedDataset.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/model/SelectedDataset.java
@@ -28,11 +28,11 @@ import edu.cmu.tetrad.util.TetradSerializableUtils;
 import java.io.Serial;
 
 /**
- * Applies a logarithmic transform.
+ * Extracts a single dataset from a data box containing multiple datasets.
  *
- * @author Jeremy Espino
+ * @author josephramsey
  */
-public class LogData extends DataWrapper {
+public class SelectedDataset extends DataWrapper {
     @Serial
     private static final long serialVersionUID = 23L;
 
@@ -44,27 +44,14 @@ public class LogData extends DataWrapper {
      * @param wrapper The data to transform.
      * @param params  The parameters for the transformation.
      */
-    public LogData(DataWrapper wrapper, Parameters params) {
+    public SelectedDataset(DataWrapper wrapper, Parameters params) {
         DataModelList inList = wrapper.getDataModelList();
         DataModelList outList = new DataModelList();
-
-        for (DataModel model : inList) {
-            if (!(model instanceof DataSet dataSet)) {
-                throw new IllegalArgumentException("Not a data set: " + model.getName());
-            }
-
-            double a = params.getDouble("a");
-            boolean isUnlog = params.getBoolean("unlog");
-            int base = params.getInt("base");
-
-            DataSet dataSet2 = DataTransforms.logData(dataSet, a, isUnlog, base);
-            outList.add(dataSet2);
-        }
-
+        DataModel selected = inList.getSelectedModel();
+        outList.add(selected);
         setDataModel(outList);
         setSourceGraph(wrapper.getSourceGraph());
-
-        LogDataUtils.logDataModelList("Logarithmic conversion of data.", getDataModelList());
+        LogDataUtils.logDataModelList("Extracted Data Model", getDataModelList());
 
     }
 

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/model/datamanip/SplitCasesWrapper.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/model/datamanip/SplitCasesWrapper.java
@@ -28,6 +28,7 @@ import edu.cmu.tetrad.util.TetradSerializableUtils;
 import edu.cmu.tetradapp.model.DataWrapper;
 import edu.cmu.tetradapp.model.PcRunner;
 
+import java.io.Serial;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -37,6 +38,7 @@ import java.util.List;
  * @author Tyler Gibson
  */
 public class SplitCasesWrapper extends DataWrapper {
+    @Serial
     private static final long serialVersionUID = 23L;
 
     /**
@@ -82,7 +84,7 @@ public class SplitCasesWrapper extends DataWrapper {
         }
 
         SplitCasesSpec spec = (SplitCasesSpec) params.get("splitCasesSpec", null);
-        int numSplits = params.getInt("numSplits", 3);
+        int numSplits = params.getInt("numSplits", 2);
         int sampleSize = spec.getSampleSize();
         int[] breakpoints = spec.getBreakpoints();
         List<String> splitNames = spec.getSplitNames();

--- a/tetrad-gui/src/main/resources/config/devConfig.xml
+++ b/tetrad-gui/src/main/resources/config/devConfig.xml
@@ -436,6 +436,17 @@
                 </model-class>
                 <editor-class>edu.cmu.tetradapp.editor.DataEditor</editor-class>
             </model>
+            <model name="Selected Dataset" acronym="Selected Dataset"
+                   help="extractselecteddata" category="Manipulation of Data">
+                <logger>
+                    <event id="info" description="Information" default="on"/>
+                    <event id="data" description="Data"/>
+                </logger>
+                <model-class>
+                    edu.cmu.tetradapp.model.SelectedDataset
+                </model-class>
+                <editor-class>edu.cmu.tetradapp.editor.DataEditor</editor-class>
+            </model>
             <!--<model name="Shift Data" acronym="Shift Data" help="data"-->
             <!--category="Manipulation of Data">-->
             <!--<logger>-->

--- a/tetrad-gui/src/main/resources/config/prodConfig.xml
+++ b/tetrad-gui/src/main/resources/config/prodConfig.xml
@@ -409,6 +409,17 @@
                 </model-class>
                 <editor-class>edu.cmu.tetradapp.editor.DataEditor</editor-class>
             </model>
+            <model name="Selected Dataset" acronym="Selected Dataset"
+                   help="extractselecteddata" category="Manipulation of Data">
+                <logger>
+                    <event id="info" description="Information" default="on"/>
+                    <event id="data" description="Data"/>
+                </logger>
+                <model-class>
+                    edu.cmu.tetradapp.model.SelectedDataset
+                </model-class>
+                <editor-class>edu.cmu.tetradapp.editor.DataEditor</editor-class>
+            </model>
             <model name="Convert to Correlation Matrix" acronym="Corr Matrix"
                    help="corr" category="Conversion of Data">
                 <logger>


### PR DESCRIPTION
Added a simple feature to copy the selected data model from a data box containing multiple data models into a separate data box. This can be useful if the user used the data split feature to extract train/test data and wants to do a search o the training data, e.g.