### PR TITLE
Replaced deprecated method Class.newInstance().

### DIFF
--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/search/AlgorithmCard.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/search/AlgorithmCard.java
@@ -384,7 +384,7 @@ public class AlgorithmCard extends JPanel {
 
         try {
             algorithm = AlgorithmFactory.create(algoClass, indTestClass, scoreClass);
-        } catch (IllegalAccessException | InstantiationException exception) {
+        } catch (IllegalAccessException | InstantiationException | InvocationTargetException exception) {
             TetradLogger.getInstance().forceLogMessage(exception.toString());
         }
 


### PR DESCRIPTION
These changes are necessary for causal-cmd to work with Java 17.