### PR TITLE
Added IDA minimum beta values to the MarkovCheck and MarkovCheckEditor classes.

### DIFF
--- a/tetrad-gui/pom.xml
+++ b/tetrad-gui/pom.xml
@@ -151,10 +151,15 @@
             <version>4.13.2</version>
         </dependency>
         <!-- Used for deep copy dataset during determinism - Zhou -->
+<!--        <dependency>-->
+<!--            <groupId>org.apache.commons</groupId>-->
+<!--            <artifactId>commons-lang3</artifactId>-->
+<!--            <version>3.12.0</version>-->
+<!--        </dependency>-->
         <dependency>
             <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.12.0</version>
+            <artifactId>commons-text</artifactId>
+            <version>1.11.0</version>
         </dependency>
         <dependency>
             <groupId>jdepend</groupId>

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/app/LoadSessionAction.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/app/LoadSessionAction.java
@@ -22,6 +22,7 @@
 package edu.cmu.tetradapp.app;
 
 import edu.cmu.tetrad.util.JOptionUtils;
+import edu.cmu.tetrad.util.TetradLogger;
 import edu.cmu.tetrad.util.Version;
 import edu.cmu.tetradapp.model.SessionWrapper;
 import edu.cmu.tetradapp.model.TetradMetadata;
@@ -39,9 +40,7 @@ import java.util.prefs.Preferences;
 
 
 /**
- * Opens a session from a file.
- *
- * @author josephramsey
+ * Represents an action to load a session from a file. Extends AbstractAction class.
  */
 final class LoadSessionAction extends AbstractAction {
 
@@ -53,14 +52,11 @@ final class LoadSessionAction extends AbstractAction {
     }
 
     /**
-     * {@inheritDoc}
-     * <p>
-     * Performs the action of opening a session from a file.
+     * Opens a session file and loads it into Tetrad.
+     *
+     * @param e the event to be processed
      */
     public void actionPerformed(ActionEvent e) {
-
-        Window owner = (Window) JOptionUtils.centeringComp().getTopLevelAncestor();
-
 
         // select a file to open using the file chooser
         JFileChooser chooser = new JFileChooser();
@@ -82,7 +78,6 @@ final class LoadSessionAction extends AbstractAction {
         }
 
         File file = chooser.getSelectedFile();
-//        final File file = EditorUtils.ensureSuffix(file0, "tet");
 
         if (file == null) {
             return;
@@ -128,7 +123,7 @@ final class LoadSessionAction extends AbstractAction {
 
                             throw e1;
                         } catch (Exception e2) {
-                            e2.printStackTrace();
+                            TetradLogger.getInstance().forceLogMessage("Exception: " + e2.getMessage());
                         }
                     } else if (o instanceof SessionWrapper) {
                         sessionWrapper = (SessionWrapper) o;
@@ -166,7 +161,6 @@ final class LoadSessionAction extends AbstractAction {
                 } catch (FileNotFoundException ex) {
                     JOptionPane.showMessageDialog(JOptionUtils.centeringComp(), "That wasn't a TETRAD session file: " + file);
                 } catch (Exception ex) {
-                    ex.printStackTrace();
                     JOptionPane.showMessageDialog(JOptionUtils.centeringComp(), "An error occurred attempting to load the session.");
                 }
             }
@@ -175,14 +169,16 @@ final class LoadSessionAction extends AbstractAction {
         new MyWatchedProcess();
     }
 
-
+    /**
+     * Represents a decompressible input stream for deserializing objects.
+     */
     public static class DecompressibleInputStream extends ObjectInputStream {
 
         public DecompressibleInputStream(InputStream in) throws IOException {
             super(in);
         }
 
-        public Class<?> resolveClass(ObjectStreamClass desc) throws IOException, ClassNotFoundException {
+        public Class<?> resolveClass(ObjectStreamClass desc) throws ClassNotFoundException {
             String remappedClassName = mapToCurrentPackageName(desc.getName());
             return Class.forName(remappedClassName);
         }

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/GeneralizedTemplateEditor.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/GeneralizedTemplateEditor.java
@@ -535,18 +535,15 @@ class GeneralizedTemplateEditor extends JComponent {
     //==============================================PRIVATE METHODS============================================//
 
     private void setParseText(String text) {
-        SwingUtilities.invokeLater(new Runnable() {
-            @Override
-            public void run() {
-                try {
+        SwingUtilities.invokeLater(() -> {
+            try {
 
-                    // Add the text to the document
-                    expressionTextDoc.remove(0, expressionTextPane.getText().length());
-                    expressionTextDoc.insertString(0, text, null);
-                } catch (BadLocationException e) {
-                    TetradLogger.getInstance().forceLogMessage(e.getMessage());
-                    throw new RuntimeException(e);
-                }
+                // Add the text to the document
+                expressionTextDoc.remove(0, expressionTextPane.getText().length());
+                expressionTextDoc.insertString(0, text, null);
+            } catch (BadLocationException e) {
+                TetradLogger.getInstance().forceLogMessage(e.getMessage());
+                throw new RuntimeException(e);
             }
         });
     }

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/LoadGraph.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/LoadGraph.java
@@ -32,9 +32,7 @@ import java.io.File;
 import java.util.prefs.Preferences;
 
 /**
- * Saves out a PNG image for a component.
- *
- * @author josephramsey
+ * LoadGraph is an action that allows the user to load a session from a file.
  */
 class LoadGraph extends AbstractAction {
 
@@ -70,9 +68,10 @@ class LoadGraph extends AbstractAction {
     }
 
     /**
-     * {@inheritDoc}
-     * <p>
-     * Performs the action of loading a session from a file.
+     * Processes the event triggered by an action. This method is called when the user interacts with a component that
+     * triggers an action event, such as a button.
+     *
+     * @param e the event to be processed
      */
     public void actionPerformed(ActionEvent e) {
         JFileChooser chooser = LoadGraph.getJFileChooser();

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/MarkovCheckEditor.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/MarkovCheckEditor.java
@@ -582,13 +582,15 @@ public class MarkovCheckEditor extends JPanel {
                     return "Test Result";
                 } else if (column == 3) {
                     return "P-value or Bump";
+                } else if (model.getMarkovCheck().isCpdag() && column == 4) {
+                    return "Min Beta";
                 }
 
                 return null;
             }
 
             public int getColumnCount() {
-                return 4;
+                return model.getMarkovCheck().isCpdag() ? 5 : 4;
             }
 
             public int getRowCount() {
@@ -632,6 +634,14 @@ public class MarkovCheckEditor extends JPanel {
 
                 if (columnIndex == 3) {
                     return nf.format(result.getPValue());
+                }
+
+                if (columnIndex == 4 && model.getMarkovCheck().isCpdag()) {
+                    IndependenceFact fact = model.getResults(true).get(rowIndex).getFact();
+                    Node x = fact.getX();
+                    Node y = fact.getY();
+                    double minBeta = model.getMarkovCheck().getMinBeta(x, y);
+                    return NumberFormatUtil.getInstance().getNumberFormat().format(minBeta);
                 }
 
                 return null;
@@ -755,22 +765,24 @@ public class MarkovCheckEditor extends JPanel {
                     return "Test Result";
                 } else if (column == 3) {
                     return "P-value or Bump";
+                } else if (model.getMarkovCheck().isCpdag() && column == 4) {
+                    return "Min Beta";
                 }
 
                 return null;
             }
 
             public int getColumnCount() {
-                return 4;
+                return model.getMarkovCheck().isCpdag() ? 5 : 4;
             }
 
             public int getRowCount() {
-                List<IndependenceResult> results = model.getResults(true);
+                List<IndependenceResult> results = model.getResults(false);
                 return results.size();
             }
 
             public Object getValueAt(int rowIndex, int columnIndex) {
-                if (rowIndex > model.getResults(true).size()) {
+                if (rowIndex > model.getResults(false).size()) {
                     return null;
                 }
 
@@ -778,10 +790,10 @@ public class MarkovCheckEditor extends JPanel {
                     return rowIndex + 1;
                 }
 
-                IndependenceResult result = model.getResults(true).get(rowIndex);
+                IndependenceResult result = model.getResults(false).get(rowIndex);
 
                 if (columnIndex == 1) {
-                    IndependenceFact fact = model.getResults(true).get(rowIndex).getFact();
+                    IndependenceFact fact = model.getResults(false).get(rowIndex).getFact();
                     List<Node> Z = new ArrayList<>(fact.getZ());
                     String z = Z.stream().map(Node::getName).collect(Collectors.joining(", "));
                     return "Ind(" + fact.getX() + ", " + fact.getY() + (Z.isEmpty() ? "" : " | " + z) + ")";
@@ -805,6 +817,14 @@ public class MarkovCheckEditor extends JPanel {
 
                 if (columnIndex == 3) {
                     return nf.format(result.getPValue());
+                }
+
+                if (columnIndex == 4 && model.getMarkovCheck().isCpdag()) {
+                    IndependenceFact fact = model.getResults(false).get(rowIndex).getFact();
+                    Node x = fact.getX();
+                    Node y = fact.getY();
+                    double minBeta = model.getMarkovCheck().getMinBeta(x, y);
+                    return NumberFormatUtil.getInstance().getNumberFormat().format(minBeta);
                 }
 
                 return null;

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/model/MarkovCheckIndTestModel.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/model/MarkovCheckIndTestModel.java
@@ -211,7 +211,7 @@ public class MarkovCheckIndTestModel implements SessionModel, GraphSource, Knowl
     /**
      * Returns the results of the Markov check.
      *
-     * @param indep whether to return the results for the independence test or the dependence test.
+     * @param indep whether to return the results for the independence test (true) or the dependence test (false).
      * @return the results of the Markov check.
      */
     public List<IndependenceResult> getResults(boolean indep) {

--- a/tetrad-lib/pom.xml
+++ b/tetrad-lib/pom.xml
@@ -71,10 +71,15 @@
             <artifactId>commons-collections4</artifactId>
             <version>4.4</version>
         </dependency>
+<!--        <dependency>-->
+<!--            <groupId>org.apache.commons</groupId>-->
+<!--            <artifactId>commons-lang3</artifactId>-->
+<!--            <version>3.14.0</version>-->
+<!--        </dependency>-->
         <dependency>
             <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.14.0</version>
+            <artifactId>commons-text</artifactId>
+            <version>1.11.0</version>
         </dependency>
         <dependency>
             <groupId>colt</groupId>

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/cpdag/Fges.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/cpdag/Fges.java
@@ -27,6 +27,8 @@ import java.io.Serial;
 import java.util.ArrayList;
 import java.util.List;
 
+import static edu.cmu.tetrad.search.utils.LogUtilsSearch.stampWithBic;
+
 /**
  * FGES (the heuristic version).
  *
@@ -130,10 +132,6 @@ public class Fges implements Algorithm, HasKnowledge, UsesScoreWrapper, TakesExt
             }
 
             graph = search.search();
-
-            if (dataModel.isContinuous() && !graph.getAllAttributes().containsKey("BIC")) {
-                graph.addAttribute("BIC", new BicEst().getValue(null, graph, dataModel));
-            }
 
             LogUtilsSearch.stampWithScore(graph, score);
             LogUtilsSearch.stampWithBic(graph, dataModel);

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/annotation/AnnotatedClass.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/annotation/AnnotatedClass.java
@@ -21,16 +21,38 @@ package edu.cmu.tetrad.annotation;
 import java.io.Serial;
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
+import java.util.Objects;
 
 /**
  * AnnotatedClass represents a class along with its associated annotation.
- *
- * @param <T> the type of the annotation
  */
-public record AnnotatedClass<T extends Annotation>(Class<?> clazz, T annotation) implements Serializable {
+public final class AnnotatedClass<T extends Annotation> implements Serializable {
 
     @Serial
     private static final long serialVersionUID = 5060798016477163171L;
+
+    /**
+     * Represents a Class used as a parameter to an AnnotatedClass object.
+     * It is stored as a private final member in the AnnotatedClass class.
+     *
+     * <p>
+     * Example usage:
+     * </p>
+     *
+     * <pre>
+     * AnnotatedClass&lt;MyAnnotation&gt; annotatedClass = new AnnotatedClass&lt;&gt;(MyClass.class, myAnnotation);
+     * Class&lt;?&gt; clazz = annotatedClass.clazz();
+     * </pre>
+     *
+     * @see AnnotatedClass
+     */
+    private final Class<?> clazz;
+
+    /**
+     * AnnotatedClass represents a class along with its associated annotation.
+     */
+    private final T annotation;
+
 
     /**
      * Creates an annotated class.
@@ -38,7 +60,9 @@ public record AnnotatedClass<T extends Annotation>(Class<?> clazz, T annotation)
      * @param clazz      class
      * @param annotation annotation
      */
-    public AnnotatedClass {
+    public AnnotatedClass(Class<?> clazz, T annotation) {
+        this.clazz = clazz;
+        this.annotation = annotation;
     }
 
     /**
@@ -46,7 +70,6 @@ public record AnnotatedClass<T extends Annotation>(Class<?> clazz, T annotation)
      *
      * @return class
      */
-    @Override
     public Class<?> clazz() {
         return this.clazz;
     }
@@ -56,9 +79,30 @@ public record AnnotatedClass<T extends Annotation>(Class<?> clazz, T annotation)
      *
      * @return annotation
      */
-    @Override
     public T annotation() {
         return this.annotation;
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        @SuppressWarnings("rawtypes") var that = (AnnotatedClass) obj;
+        return Objects.equals(this.clazz, that.clazz) &&
+                Objects.equals(this.annotation, that.annotation);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(clazz, annotation);
+    }
+
+    @Override
+    public String toString() {
+        return "AnnotatedClass[" +
+                "clazz=" + clazz + ", " +
+                "annotation=" + annotation + ']';
+    }
+
 
 }

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/Ida.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/Ida.java
@@ -100,12 +100,13 @@ public class Ida {
     }
 
     /**
-     * Calculates the true effect of (x, y) given the true DAG (which must be provided).
+     * Calculates the true effect of node x on node y in a given graph.
      *
-     * @param trueDag The true DAG.
-     * @param x       a {@link edu.cmu.tetrad.graph.Node} object
-     * @param y       a {@link edu.cmu.tetrad.graph.Node} object
-     * @return The true effect of (x, y).
+     * @param x       The first node.
+     * @param y       The second node.
+     * @param trueDag The graph representing the true underlying causal structure.
+     * @return The true effect of x on y.
+     * @throws IllegalArgumentException If x is equal to y.
      */
     public double trueEffect(Node x, Node y, Graph trueDag) {
         if (x == y) throw new IllegalArgumentException("x == y");

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/MarkovCheck.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/MarkovCheck.java
@@ -967,7 +967,9 @@ public class MarkovCheck {
     }
 
     /**
-     * Indicates whether the graph is a legal CPDAG.
+     * Checks whether the given graph is a CPDAG (Completed Partially Directed Acyclic Graph).
+     *
+     * @return true if the graph is a CPDAG, false otherwise
      */
     public boolean isCpdag() {
         return isCpdag;

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/test/IndependenceResult.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/test/IndependenceResult.java
@@ -9,8 +9,8 @@ import edu.cmu.tetrad.util.TetradSerializableUtils;
 import java.io.Serial;
 
 /**
- * Stores a single conditional independence result, e.g., whether X _||_ Y | Z1,..,Zn holds or does not, and the p-value
- * of the test.
+ * Stores a single conditional independence result, e.g., whether X _||_ Y | Z1,...,Zn holds or does not, and the
+ * p-value of the test.
  *
  * @author josephramsey
  * @version $Id: $Id
@@ -39,7 +39,6 @@ public final class IndependenceResult implements TetradSerializable {
      * score.
      */
     private final double score;
-
     /**
      * Whether the result is valid or not. A test is not valid if the test is not able to determine whether the fact
      * holds or not.
@@ -89,7 +88,7 @@ public final class IndependenceResult implements TetradSerializable {
     public static IndependenceResult serializableInstance() {
         return new IndependenceResult(new IndependenceFact(
                 new ContinuousVariable("X"), new ContinuousVariable("Y")),
-                true, 0.0001, 1.0);
+                true, 0.0001, 0.0, true);
     }
 
     /**
@@ -103,9 +102,9 @@ public final class IndependenceResult implements TetradSerializable {
     }
 
     /**
-     * Returns whether the fact holds--i.e., if the judgment is for independence.
+     * Returns true if the judgment is for independence, false if for dependence.
      *
-     * @return True if the fact holds, false if ot.
+     * @return True if the fact holds, false if not.
      * @see #isDependent()
      */
     public boolean isIndependent() {
@@ -113,8 +112,8 @@ public final class IndependenceResult implements TetradSerializable {
     }
 
     /**
-     * Returns whether the fact fails to hold--i.e., if the judgment is for dependence. This is the negation of
-     * isIndependent.
+     * Returns whether the fact fails to hold--i.e. if the judgment is for dependence. This is the negation of
+     * isIndependent().
      *
      * @return True if the fact does not, false if it does.
      * @see #isIndependent()

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/util/TetradLogger.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/util/TetradLogger.java
@@ -579,12 +579,17 @@ public class TetradLogger {
     }
 
     /**
-     * Represents an empty logger configuration.
+     * Represents an empty configuration for the logger. It implements the TetradLoggerConfig interface.
      */
-    public record EmptyConfig(boolean active) implements TetradLoggerConfig {
+    public static class EmptyConfig implements TetradLoggerConfig {
 
         @Serial
         private static final long serialVersionUID = 23L;
+
+        /**
+         * Represents the activation status of an event in the logger configuration.
+         */
+        private final boolean active;
 
         /**
          * <p>Constructor for EmptyConfig.</p>
@@ -592,7 +597,8 @@ public class TetradLogger {
          * @param active a boolean
          */
         @SuppressWarnings("SameParameterValue")
-        public EmptyConfig {
+        public EmptyConfig(boolean active) {
+            this.active = active;
         }
 
         /**


### PR DESCRIPTION
To test this, in the Tetrad interface, run a CPDAG algrothm like BOSS and then add a comparison box and do a Markov check. There should now (int his branch) be a new column in the implied independencies and implied dependencies tabs with these min betas. The IDA beta for x to y is listed in the row for x _||_ y | parents(x) (or x ~_||_ y | parents(x). For the independence case these numbers should be small, but for the dependence case there should be a number of large betas.