### PR TITLE
Added a field to indicate if a stop button has clicked.

### DIFF
--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/GeneralAlgorithmEditor.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/GeneralAlgorithmEditor.java
@@ -244,14 +244,17 @@ public class GeneralAlgorithmEditor extends JPanel implements PropertyChangeList
 
                         firePropertyChange("modelChanged", null, null);
                         GeneralAlgorithmEditor.this.graphCard.refresh();
-                        showGraphCard();
+
+                        if (!isInterrupted()) {
+                            showGraphCard();
+                        }
                     } catch (Exception exception) {
                         exception.printStackTrace(System.err);
 
                         JOptionPane.showMessageDialog(
                                 getTopLevelAncestor(),
                                 "Stopped with error:\n"
-                                        + exception.getMessage());
+                                + exception.getMessage());
                     }
                 }
             }

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/util/WatchedProcess.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/util/WatchedProcess.java
@@ -38,6 +38,8 @@ public abstract class WatchedProcess {
     private final JFrame frame;
     private Thread longRunningThread;
     private JDialog dialog;
+    
+    private boolean interrupted;
 
     /**
      * Constructor.
@@ -119,6 +121,8 @@ public abstract class WatchedProcess {
             if (dialog != null) {
                 SwingUtilities.invokeLater(() -> dialog.dispose());
             }
+
+            interrupted = true;
         });
 
         JPanel panel = new JPanel();
@@ -131,4 +135,9 @@ public abstract class WatchedProcess {
 
         SwingUtilities.invokeLater(() -> dialog.setVisible(true));
     }
+
+    public boolean isInterrupted() {
+        return interrupted;
+    }
+
 }


### PR DESCRIPTION
A fix for issue #1740.  Clicking on the cancelling button during search will stop the search and stay on the Parameter panel instead of switching to a Graph panel with an empty graph.