### PR TITLE
Propagate exception from running tasks to the process watcher.

### DIFF
--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/GeneralAlgorithmEditor.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/GeneralAlgorithmEditor.java
@@ -250,6 +250,8 @@ public class GeneralAlgorithmEditor extends JPanel implements PropertyChangeList
                         }
                     } catch (Exception exception) {
                         exception.printStackTrace(System.err);
+                        
+                        disposeStopDialog();
 
                         JOptionPane.showMessageDialog(
                                 getTopLevelAncestor(),

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/util/WatchedProcess.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/util/WatchedProcess.java
@@ -94,6 +94,12 @@ public abstract class WatchedProcess {
         longRunningThread.start();
     }
 
+    protected void disposeStopDialog() {
+        if (dialog != null) {
+            SwingUtilities.invokeLater(() -> dialog.dispose());
+        }
+    }
+
     private void showStopDialog() {
         dialog = new JDialog(frame, "Stop Process", Dialog.ModalityType.APPLICATION_MODAL);
         dialog.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/util/TaskRunner.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/util/TaskRunner.java
@@ -41,8 +41,8 @@ public class TaskRunner<T> {
     private final ExecutorService pool;
 
     /**
-     * This class is responsible for running a list of tasks that implement the Callable interface in parallel using
-     * multiple threads.
+     * This class is responsible for running a list of tasks that implement the
+     * Callable interface in parallel using multiple threads.
      */
     public TaskRunner() {
         this(Runtime.getRuntime().availableProcessors());
@@ -58,7 +58,8 @@ public class TaskRunner<T> {
     }
 
     /**
-     * Executes a list of tasks that implement Callable in parallel using multiple threads.
+     * Executes a list of tasks that implement Callable in parallel using
+     * multiple threads.
      *
      * @param tasks the list of tasks to execute
      * @return a list of results from the completed tasks
@@ -82,8 +83,10 @@ public class TaskRunner<T> {
             for (Future<T> completedTask : completedTasks) {
                 results.add(completedTask.get());
             }
-        } catch (ExecutionException | InterruptedException exception) {
+        } catch (InterruptedException exception) {
             LOGGER.error("", exception);
+        } catch (ExecutionException exception) {
+            throw new RuntimeException(exception.getCause().getMessage());
         }
 
         return results;
@@ -92,12 +95,15 @@ public class TaskRunner<T> {
     /**
      * Shuts down an ExecutorService and awaits its termination.
      * <p>
-     * This method gracefully shuts down the ExecutorService by calling {@link ExecutorService#shutdown()} and then
-     * waits for the termination of all tasks for a specified timeout period using the
-     * {@link ExecutorService#awaitTermination(long, TimeUnit)} method. If the tasks do not terminate within the timeout
-     * period, the method forcefully shuts down the ExecutorService by calling {@link ExecutorService#shutdownNow()} and
-     * waits again for the termination using {@link ExecutorService#awaitTermination(long, TimeUnit)}. If the tasks
-     * still do not terminate, an error message is logged.
+     * This method gracefully shuts down the ExecutorService by calling
+     * {@link ExecutorService#shutdown()} and then waits for the termination of
+     * all tasks for a specified timeout period using the
+     * {@link ExecutorService#awaitTermination(long, TimeUnit)} method. If the
+     * tasks do not terminate within the timeout period, the method forcefully
+     * shuts down the ExecutorService by calling
+     * {@link ExecutorService#shutdownNow()} and waits again for the termination
+     * using {@link ExecutorService#awaitTermination(long, TimeUnit)}. If the
+     * tasks still do not terminate, an error message is logged.
      *
      * @param pool the ExecutorService to shut down and await termination
      */


### PR DESCRIPTION
Propagate exception from running tasks to the process watcher. so that exception could be catched.  The changes also includes a fix for issue #1741.