### PR TITLE
Responding to bug reports from Peter.

### DIFF
--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/DagEditor.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/DagEditor.java
@@ -312,39 +312,39 @@ public final class DagEditor extends JPanel
         Box instructionBox = Box.createHorizontalBox();
         instructionBox.setMaximumSize(new Dimension(820, 40));
 
-        JLabel label = new JLabel("Double click variable/node rectangle to change name. More information on graph edge types and colorings");
-        label.setFont(new Font("SansSerif", Font.PLAIN, 12));
-
-        // Info button added by Zhou to show edge types
-        JButton infoBtn = new JButton(new ImageIcon(ImageUtils.getImage(this, "info.png")));
-        infoBtn.setBorder(new EmptyBorder(0, 0, 0, 0));
-
-        // Clock info button to show edge types instructions - Zhou
-        infoBtn.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                // Initialize helpSet
-                final String helpHS = "/docs/javahelp/TetradHelp.hs";
-
-                try {
-                    URL url = this.getClass().getResource(helpHS);
-                    HelpSet helpSet = new HelpSet(null, url);
-
-                    helpSet.setHomeID("graph_edge_types");
-                    HelpBroker broker = helpSet.createHelpBroker();
-                    ActionListener listener = new CSH.DisplayHelpFromSource(broker);
-                    listener.actionPerformed(e);
-                } catch (Exception ee) {
-                    System.out.println("HelpSet " + ee.getMessage());
-                    System.out.println("HelpSet " + helpHS + " not found");
-                    throw new IllegalArgumentException();
-                }
-            }
-        });
-
-        instructionBox.add(label);
-        instructionBox.add(Box.createHorizontalStrut(2));
-        instructionBox.add(infoBtn);
+//        JLabel label = new JLabel("Double click variable/node rectangle to change name. More information on graph edge types");
+//        label.setFont(new Font("SansSerif", Font.PLAIN, 12));
+//
+//        // Info button added by Zhou to show edge types
+//        JButton infoBtn = new JButton(new ImageIcon(ImageUtils.getImage(this, "info.png")));
+//        infoBtn.setBorder(new EmptyBorder(0, 0, 0, 0));
+//
+//        // Clock info button to show edge types instructions - Zhou
+//        infoBtn.addActionListener(new ActionListener() {
+//            @Override
+//            public void actionPerformed(ActionEvent e) {
+//                // Initialize helpSet
+//                final String helpHS = "/docs/javahelp/TetradHelp.hs";
+//
+//                try {
+//                    URL url = this.getClass().getResource(helpHS);
+//                    HelpSet helpSet = new HelpSet(null, url);
+//
+//                    helpSet.setHomeID("graph_edge_types");
+//                    HelpBroker broker = helpSet.createHelpBroker();
+//                    ActionListener listener = new CSH.DisplayHelpFromSource(broker);
+//                    listener.actionPerformed(e);
+//                } catch (Exception ee) {
+//                    System.out.println("HelpSet " + ee.getMessage());
+//                    System.out.println("HelpSet " + helpHS + " not found");
+//                    throw new IllegalArgumentException();
+//                }
+//            }
+//        });
+//
+//        instructionBox.add(label);
+//        instructionBox.add(Box.createHorizontalStrut(2));
+//        instructionBox.add(infoBtn);
 
         // Add to topBox
         topBox.add(topGraphBox);

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/DagEditor.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/DagEditor.java
@@ -312,9 +312,9 @@ public final class DagEditor extends JPanel
         Box instructionBox = Box.createHorizontalBox();
         instructionBox.setMaximumSize(new Dimension(820, 40));
 
-//        JLabel label = new JLabel("Double click variable/node rectangle to change name. More information on graph edge types");
-//        label.setFont(new Font("SansSerif", Font.PLAIN, 12));
-//
+        JLabel label = new JLabel("Double click variable/node rectangle to change name.");
+        label.setFont(new Font("SansSerif", Font.PLAIN, 12));
+
 //        // Info button added by Zhou to show edge types
 //        JButton infoBtn = new JButton(new ImageIcon(ImageUtils.getImage(this, "info.png")));
 //        infoBtn.setBorder(new EmptyBorder(0, 0, 0, 0));
@@ -342,7 +342,7 @@ public final class DagEditor extends JPanel
 //            }
 //        });
 //
-//        instructionBox.add(label);
+        instructionBox.add(label);
 //        instructionBox.add(Box.createHorizontalStrut(2));
 //        instructionBox.add(infoBtn);
 

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/GeneralAlgorithmEditor.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/GeneralAlgorithmEditor.java
@@ -244,14 +244,19 @@ public class GeneralAlgorithmEditor extends JPanel implements PropertyChangeList
 
                         firePropertyChange("modelChanged", null, null);
                         GeneralAlgorithmEditor.this.graphCard.refresh();
-                        showGraphCard();
+
+                        if (!isInterrupted()) {
+                            showGraphCard();
+                        }
                     } catch (Exception exception) {
                         exception.printStackTrace(System.err);
+
+                        disposeStopDialog();
 
                         JOptionPane.showMessageDialog(
                                 getTopLevelAncestor(),
                                 "Stopped with error:\n"
-                                        + exception.getMessage());
+                                + exception.getMessage());
                     }
                 }
             }

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/GraphEditor.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/GraphEditor.java
@@ -314,8 +314,8 @@ public final class GraphEditor extends JPanel implements GraphEditable, LayoutEd
         Box instructionBox = Box.createHorizontalBox();
         instructionBox.setMaximumSize(new Dimension(820, 40));
 
-//        JLabel label = new JLabel("Double click variable/node rectangle to change name. More information on graph edge types");
-//        label.setFont(new Font("SansSerif", Font.PLAIN, 12));
+        JLabel label = new JLabel("Double click variable/node rectangle to change name.");
+        label.setFont(new Font("SansSerif", Font.PLAIN, 12));
 //
         // Info button added by Zhou to show edge types
 //        JButton infoBtn = new JButton(new ImageIcon(ImageUtils.getImage(this, "info.png")));
@@ -344,7 +344,7 @@ public final class GraphEditor extends JPanel implements GraphEditable, LayoutEd
 //            }
 //        });
 //
-//        instructionBox.add(label);
+        instructionBox.add(label);
 //        instructionBox.add(Box.createHorizontalStrut(2));
 //        instructionBox.add(infoBtn);
 

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/GraphEditor.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/GraphEditor.java
@@ -314,39 +314,39 @@ public final class GraphEditor extends JPanel implements GraphEditable, LayoutEd
         Box instructionBox = Box.createHorizontalBox();
         instructionBox.setMaximumSize(new Dimension(820, 40));
 
-        JLabel label = new JLabel("Double click variable/node rectangle to change name. More information on graph edge types and colorings");
-        label.setFont(new Font("SansSerif", Font.PLAIN, 12));
-
+//        JLabel label = new JLabel("Double click variable/node rectangle to change name. More information on graph edge types");
+//        label.setFont(new Font("SansSerif", Font.PLAIN, 12));
+//
         // Info button added by Zhou to show edge types
-        JButton infoBtn = new JButton(new ImageIcon(ImageUtils.getImage(this, "info.png")));
-        infoBtn.setBorder(new EmptyBorder(0, 0, 0, 0));
-
-        // Clock info button to show edge types instructions - Zhou
-        infoBtn.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                // Initialize helpSet
-                final String helpHS = "/docs/javahelp/TetradHelp.hs";
-
-                try {
-                    URL url = this.getClass().getResource(helpHS);
-                    HelpSet helpSet = new HelpSet(null, url);
-
-                    helpSet.setHomeID("graph_edge_types");
-                    HelpBroker broker = helpSet.createHelpBroker();
-                    ActionListener listener = new CSH.DisplayHelpFromSource(broker);
-                    listener.actionPerformed(e);
-                } catch (Exception ee) {
-                    System.out.println("HelpSet " + ee.getMessage());
-                    System.out.println("HelpSet " + helpHS + " not found");
-                    throw new IllegalArgumentException();
-                }
-            }
-        });
-
-        instructionBox.add(label);
-        instructionBox.add(Box.createHorizontalStrut(2));
-        instructionBox.add(infoBtn);
+//        JButton infoBtn = new JButton(new ImageIcon(ImageUtils.getImage(this, "info.png")));
+//        infoBtn.setBorder(new EmptyBorder(0, 0, 0, 0));
+//
+//        // Clock info button to show edge types instructions - Zhou
+//        infoBtn.addActionListener(new ActionListener() {
+//            @Override
+//            public void actionPerformed(ActionEvent e) {
+//                // Initialize helpSet
+//                final String helpHS = "/docs/javahelp/TetradHelp.hs";
+//
+//                try {
+//                    URL url = this.getClass().getResource(helpHS);
+//                    HelpSet helpSet = new HelpSet(null, url);
+//
+//                    helpSet.setHomeID("graph_edge_types");
+//                    HelpBroker broker = helpSet.createHelpBroker();
+//                    ActionListener listener = new CSH.DisplayHelpFromSource(broker);
+//                    listener.actionPerformed(e);
+//                } catch (Exception ee) {
+//                    System.out.println("HelpSet " + ee.getMessage());
+//                    System.out.println("HelpSet " + helpHS + " not found");
+//                    throw new IllegalArgumentException();
+//                }
+//            }
+//        });
+//
+//        instructionBox.add(label);
+//        instructionBox.add(Box.createHorizontalStrut(2));
+//        instructionBox.add(infoBtn);
 
         // Add to topBox
         topBox.add(topGraphBox);

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/GraphSelectionEditor.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/GraphSelectionEditor.java
@@ -203,7 +203,7 @@ public class GraphSelectionEditor extends JPanel implements GraphEditable, Tripl
         buttonPanel.add(executeButton);
 
         // Info button added by Zhou to show edge types
-        JLabel infoLabel = new JLabel("More information on graph edge types and colorings");
+        JLabel infoLabel = new JLabel("More information on FCI graph edge types");
         infoLabel.setFont(new Font("SansSerif", Font.PLAIN, 12));
 
         // Info button added by Zhou to show edge types

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/GraphSelectionEditor.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/GraphSelectionEditor.java
@@ -202,25 +202,25 @@ public class GraphSelectionEditor extends JPanel implements GraphEditable, Tripl
         // Add to buttonPanel
         buttonPanel.add(executeButton);
 
-        // Info button added by Zhou to show edge types
-        JLabel infoLabel = new JLabel("More information on FCI graph edge types");
-        infoLabel.setFont(new Font("SansSerif", Font.PLAIN, 12));
-
-        // Info button added by Zhou to show edge types
-        JButton infoBtn = new JButton(new ImageIcon(ImageUtils.getImage(this, "info.png")));
-        infoBtn.setBorder(new EmptyBorder(0, 0, 0, 0));
-
-        // Clock info button to show edge types instructions - Zhou
-        infoBtn.addActionListener(e -> {
-            helpSet.setHomeID("graph_edge_types");
-            HelpBroker broker = helpSet.createHelpBroker();
-            ActionListener listener = new CSH.DisplayHelpFromSource(broker);
-            listener.actionPerformed(e);
-        });
-
-        // Add to buttonPanel
-        buttonPanel.add(infoLabel);
-        buttonPanel.add(infoBtn);
+//        // Info button added by Zhou to show edge types
+//        JLabel infoLabel = new JLabel("More information on FCI graph edge types");
+//        infoLabel.setFont(new Font("SansSerif", Font.PLAIN, 12));
+//
+//        // Info button added by Zhou to show edge types
+//        JButton infoBtn = new JButton(new ImageIcon(ImageUtils.getImage(this, "info.png")));
+//        infoBtn.setBorder(new EmptyBorder(0, 0, 0, 0));
+//
+//        // Clock info button to show edge types instructions - Zhou
+//        infoBtn.addActionListener(e -> {
+//            helpSet.setHomeID("graph_edge_types");
+//            HelpBroker broker = helpSet.createHelpBroker();
+//            ActionListener listener = new CSH.DisplayHelpFromSource(broker);
+//            listener.actionPerformed(e);
+//        });
+//
+//        // Add to buttonPanel
+//        buttonPanel.add(infoLabel);
+//        buttonPanel.add(infoBtn);
 
         // Add top level componments to container
         add(createTopMenuBar(), BorderLayout.NORTH);

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/PagColorer.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/PagColorer.java
@@ -21,6 +21,7 @@
 
 package edu.cmu.tetradapp.editor;
 
+import edu.cmu.tetrad.graph.EdgeListGraph;
 import edu.cmu.tetrad.graph.Graph;
 import edu.cmu.tetrad.search.utils.GraphSearchUtils;
 import edu.cmu.tetradapp.util.WatchedProcess;
@@ -50,22 +51,22 @@ public class PagColorer extends JCheckBoxMenuItem {
 
         final GraphWorkbench _workbench = workbench;
 
-        Graph graph = workbench.getGraph();
-
         _workbench.setDoPagColoring(workbench.isDoPagColoring());
         setSelected(workbench.isDoPagColoring());
 
         addItemListener(e -> {
-            if (!isSelected()) {
-                workbench.setDoPagColoring(false);
-            } else {
+            _workbench.setDoPagColoring(isSelected());
+
+            if (isSelected()) {
                 int ret = JOptionPane.showConfirmDialog(workbench,
                         breakDown("Would you like to verify that this is a legal PAG?", 60),
                         "Legal PAG check", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
-                if (ret == JOptionPane.YES_NO_OPTION) {
+                if (ret == JOptionPane.YES_OPTION) {
                     class MyWatchedProcess extends WatchedProcess {
                         @Override
                         public void watch() {
+                            Graph graph = new EdgeListGraph(workbench.getGraph());
+
                             GraphSearchUtils.LegalPagRet legalPag = GraphSearchUtils.isLegalPag(graph);
                             String reason = breakDown(legalPag.getReason(), 60);
 
@@ -82,21 +83,6 @@ public class PagColorer extends JCheckBoxMenuItem {
                     }
 
                     new MyWatchedProcess();
-//                    GraphSearchUtils.LegalPagRet legalPag = GraphSearchUtils.isLegalPag(graph);
-//                    String reason = breakDown(legalPag.getReason(), 60);
-//
-//                    if (!legalPag.isLegalPag()) {
-//                        JOptionPane.showMessageDialog(workbench,
-//                                "This is not a legal PAG--one reason is as follows:" +
-//                                        "\n\n" + reason + ".",
-//                                "Legal PAG check",
-//                                JOptionPane.WARNING_MESSAGE);
-//                    } else {
-//                        JOptionPane.showMessageDialog(workbench, reason);
-//                    }
-//                }
-
-                    _workbench.setDoPagColoring(true);
                 }
             }
         });

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/PagColorer.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/PagColorer.java
@@ -105,7 +105,7 @@ public class PagColorer extends JCheckBoxMenuItem {
             }
         }
 
-        if (buf1.length() > 0) {
+        if (!buf1.isEmpty()) {
             buf2.append(buf1);
         }
 

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/SemGraphEditor.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/SemGraphEditor.java
@@ -318,39 +318,39 @@ public final class SemGraphEditor extends JPanel
         Box instructionBox = Box.createHorizontalBox();
         instructionBox.setMaximumSize(new Dimension(820, 40));
 
-        JLabel label = new JLabel("Double click variable/node rectangle to change name. More information on graph edge types and colorings");
+        JLabel label = new JLabel("Double click variable/node to change name.");
         label.setFont(new Font("SansSerif", Font.PLAIN, 12));
 
         // Info button added by Zhou to show edge types
-        JButton infoBtn = new JButton(new ImageIcon(ImageUtils.getImage(this, "info.png")));
-        infoBtn.setBorder(new EmptyBorder(0, 0, 0, 0));
+//        JButton infoBtn = new JButton(new ImageIcon(ImageUtils.getImage(this, "info.png")));
+//        infoBtn.setBorder(new EmptyBorder(0, 0, 0, 0));
 
         // Clock info button to show edge types instructions - Zhou
-        infoBtn.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                // Initialize helpSet
-                final String helpHS = "/docs/javahelp/TetradHelp.hs";
-
-                try {
-                    URL url = this.getClass().getResource(helpHS);
-                    HelpSet helpSet = new HelpSet(null, url);
-
-                    helpSet.setHomeID("graph_edge_types");
-                    HelpBroker broker = helpSet.createHelpBroker();
-                    ActionListener listener = new CSH.DisplayHelpFromSource(broker);
-                    listener.actionPerformed(e);
-                } catch (Exception ee) {
-                    System.out.println("HelpSet " + ee.getMessage());
-                    System.out.println("HelpSet " + helpHS + " not found");
-                    throw new IllegalArgumentException();
-                }
-            }
-        });
+//        infoBtn.addActionListener(new ActionListener() {
+//            @Override
+//            public void actionPerformed(ActionEvent e) {
+//                // Initialize helpSet
+//                final String helpHS = "/docs/javahelp/TetradHelp.hs";
+//
+//                try {
+//                    URL url = this.getClass().getResource(helpHS);
+//                    HelpSet helpSet = new HelpSet(null, url);
+//
+//                    helpSet.setHomeID("graph_edge_types");
+//                    HelpBroker broker = helpSet.createHelpBroker();
+//                    ActionListener listener = new CSH.DisplayHelpFromSource(broker);
+//                    listener.actionPerformed(e);
+//                } catch (Exception ee) {
+//                    System.out.println("HelpSet " + ee.getMessage());
+//                    System.out.println("HelpSet " + helpHS + " not found");
+//                    throw new IllegalArgumentException();
+//                }
+//            }
+//        });
 
         instructionBox.add(label);
         instructionBox.add(Box.createHorizontalStrut(2));
-        instructionBox.add(infoBtn);
+//        instructionBox.add(infoBtn);
 
         // Add to topBox
         topBox.add(topGraphBox);

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/TimeLagGraphEditor.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/TimeLagGraphEditor.java
@@ -286,39 +286,39 @@ public final class TimeLagGraphEditor extends JPanel
         Box instructionBox = Box.createHorizontalBox();
         instructionBox.setMaximumSize(new Dimension(820, 40));
 
-        JLabel label = new JLabel("Double click variable/node rectangle to change name. More information on graph edge types");
+        JLabel label = new JLabel("Double click variable/node to change name.");
         label.setFont(new Font("SansSerif", Font.PLAIN, 12));
 
-        // Info button added by Zhou to show edge types
-        JButton infoBtn = new JButton(new ImageIcon(ImageUtils.getImage(this, "info.png")));
-        infoBtn.setBorder(new EmptyBorder(0, 0, 0, 0));
-
-        // Clock info button to show edge types instructions - Zhou
-        infoBtn.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                // Initialize helpSet
-                final String helpHS = "/docs/javahelp/TetradHelp.hs";
-
-                try {
-                    URL url = this.getClass().getResource(helpHS);
-                    HelpSet helpSet = new HelpSet(null, url);
-
-                    helpSet.setHomeID("graph_edge_types");
-                    HelpBroker broker = helpSet.createHelpBroker();
-                    ActionListener listener = new CSH.DisplayHelpFromSource(broker);
-                    listener.actionPerformed(e);
-                } catch (Exception ee) {
-                    System.out.println("HelpSet " + ee.getMessage());
-                    System.out.println("HelpSet " + helpHS + " not found");
-                    throw new IllegalArgumentException();
-                }
-            }
-        });
-
+//        // Info button added by Zhou to show edge types
+//        JButton infoBtn = new JButton(new ImageIcon(ImageUtils.getImage(this, "info.png")));
+//        infoBtn.setBorder(new EmptyBorder(0, 0, 0, 0));
+//
+//        // Clock info button to show edge types instructions - Zhou
+//        infoBtn.addActionListener(new ActionListener() {
+//            @Override
+//            public void actionPerformed(ActionEvent e) {
+//                // Initialize helpSet
+//                final String helpHS = "/docs/javahelp/TetradHelp.hs";
+//
+//                try {
+//                    URL url = this.getClass().getResource(helpHS);
+//                    HelpSet helpSet = new HelpSet(null, url);
+//
+//                    helpSet.setHomeID("graph_edge_types");
+//                    HelpBroker broker = helpSet.createHelpBroker();
+//                    ActionListener listener = new CSH.DisplayHelpFromSource(broker);
+//                    listener.actionPerformed(e);
+//                } catch (Exception ee) {
+//                    System.out.println("HelpSet " + ee.getMessage());
+//                    System.out.println("HelpSet " + helpHS + " not found");
+//                    throw new IllegalArgumentException();
+//                }
+//            }
+//        });
+//
         instructionBox.add(label);
         instructionBox.add(Box.createHorizontalStrut(2));
-        instructionBox.add(infoBtn);
+//        instructionBox.add(infoBtn);
 
         // Add to topBox
         topBox.add(topGraphBox);

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/TimeLagGraphEditor.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/TimeLagGraphEditor.java
@@ -286,7 +286,7 @@ public final class TimeLagGraphEditor extends JPanel
         Box instructionBox = Box.createHorizontalBox();
         instructionBox.setMaximumSize(new Dimension(820, 40));
 
-        JLabel label = new JLabel("Double click variable/node rectangle to change name. More information on graph edge types and colorings");
+        JLabel label = new JLabel("Double click variable/node rectangle to change name. More information on graph edge types");
         label.setFont(new Font("SansSerif", Font.PLAIN, 12));
 
         // Info button added by Zhou to show edge types

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/search/GraphCard.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/search/GraphCard.java
@@ -151,6 +151,10 @@ public class GraphCard extends JPanel {
         graphWorkbench.setKnowledge(knowledge);
         graphWorkbench.enableEditing(false);
 
+        // If the algorithm is a latent variable algorithm, then set the graph workbench to do PAG coloring.
+        // This is to show the edge types in the graph. - jdramsey 2024/03/13
+        graphWorkbench.setDoPagColoring(GraphSearchUtils.isLatentVariableAlgorithmByAnnotation(this.algorithmRunner.getAlgorithm()));
+
         this.workbench = graphWorkbench;
 
         JPanel mainPanel = new JPanel(new BorderLayout());

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/search/GraphCard.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/search/GraphCard.java
@@ -18,10 +18,9 @@
  */
 package edu.cmu.tetradapp.editor.search;
 
-import edu.cmu.tetrad.algcomparison.algorithm.Algorithm;
-import edu.cmu.tetrad.annotation.AlgType;
 import edu.cmu.tetrad.data.Knowledge;
 import edu.cmu.tetrad.graph.Graph;
+import edu.cmu.tetrad.search.utils.GraphSearchUtils;
 import edu.cmu.tetradapp.editor.*;
 import edu.cmu.tetradapp.model.GeneralAlgorithmRunner;
 import edu.cmu.tetradapp.ui.PaddingPanel;
@@ -37,9 +36,6 @@ import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.Serial;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.net.URL;
 
 /**
@@ -76,26 +72,6 @@ public class GraphCard extends JPanel {
         this.algorithmRunner = algorithmRunner;
         this.knowledge = algorithmRunner.getKnowledge();
         initComponents();
-    }
-
-    public static boolean isLatentVariableAlgorithm(Algorithm algorithm) {
-        if (algorithm == null) {
-            throw new NullPointerException("Algorithm must not be null.");
-        }
-
-        Annotation annotation = algorithm.getClass().getAnnotationsByType(edu.cmu.tetrad.annotation.Algorithm.class)[0];
-        try {
-            Method method = annotation.annotationType().getDeclaredMethod("algoType");
-            AlgType ret = (AlgType) method.invoke(annotation);
-
-            if (ret == AlgType.allow_latent_common_causes) {
-                return true;
-            }
-        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
-            throw new RuntimeException("Error in getting algorithm type from annotation", e);
-        }
-
-        return false;
     }
 
     private void initComponents() {
@@ -181,7 +157,7 @@ public class GraphCard extends JPanel {
         mainPanel.setPreferredSize(new Dimension(825, 406));
         mainPanel.add(new JScrollPane(graphWorkbench), BorderLayout.CENTER);
 
-        if (isLatentVariableAlgorithm(this.algorithmRunner.getAlgorithm())) {
+        if (GraphSearchUtils.isLatentVariableAlgorithmByAnnotation(this.algorithmRunner.getAlgorithm())) {
             mainPanel.add(createLatentVariableInstructionBox(), BorderLayout.SOUTH);
         }
 

--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/util/WatchedProcess.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/util/WatchedProcess.java
@@ -38,6 +38,8 @@ public abstract class WatchedProcess {
     private final JFrame frame;
     private Thread longRunningThread;
     private JDialog dialog;
+    
+    private boolean interrupted;
 
     /**
      * Constructor.
@@ -92,6 +94,12 @@ public abstract class WatchedProcess {
         longRunningThread.start();
     }
 
+    protected void disposeStopDialog() {
+        if (dialog != null) {
+            SwingUtilities.invokeLater(() -> dialog.dispose());
+        }
+    }
+
     private void showStopDialog() {
         dialog = new JDialog(frame, "Stop Process", Dialog.ModalityType.APPLICATION_MODAL);
         dialog.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
@@ -119,6 +127,8 @@ public abstract class WatchedProcess {
             if (dialog != null) {
                 SwingUtilities.invokeLater(() -> dialog.dispose());
             }
+
+            interrupted = true;
         });
 
         JPanel panel = new JPanel();
@@ -131,4 +141,9 @@ public abstract class WatchedProcess {
 
         SwingUtilities.invokeLater(() -> dialog.setVisible(true));
     }
+
+    public boolean isInterrupted() {
+        return interrupted;
+    }
+
 }

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/utils/GraphSearchUtils.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/utils/GraphSearchUtils.java
@@ -21,6 +21,8 @@
 package edu.cmu.tetrad.search.utils;
 
 import edu.cmu.tetrad.algcomparison.CompareTwoGraphs;
+import edu.cmu.tetrad.algcomparison.algorithm.Algorithm;
+import edu.cmu.tetrad.annotation.AlgType;
 import edu.cmu.tetrad.data.Knowledge;
 import edu.cmu.tetrad.data.KnowledgeEdge;
 import edu.cmu.tetrad.graph.*;
@@ -32,6 +34,9 @@ import org.apache.commons.collections4.map.MultiKeyMap;
 import org.apache.commons.math3.util.FastMath;
 
 import java.io.PrintStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.*;
@@ -390,10 +395,11 @@ public final class GraphSearchUtils {
     }
 
     /**
-     * <p>isLegalPag.</p>
+     * Checks if the provided Directed Acyclic Graph (PAG) is a legal PAG.
      *
-     * @param pag a {@link edu.cmu.tetrad.graph.Graph} object
-     * @return a {@link edu.cmu.tetrad.search.utils.GraphSearchUtils.LegalPagRet} object
+     * @param pag The Directed Acyclic Graph (PAG) to be checked
+     *
+     * @return A LegalPagRet object indicating whether the PAG is legal or not, along with a reason if it is not legal.
      */
     public static LegalPagRet isLegalPag(Graph pag) {
 
@@ -1161,6 +1167,35 @@ public final class GraphSearchUtils {
         }
 
         return counts;
+    }
+
+    /**
+     * Checks if the provided algorithm is a latent variable algorithm by inspecting the associated annotation.
+     *
+     * @param algorithm The algorithm to check.
+     * @return true if the algorithm is a latent variable algorithm, false otherwise.
+     * @throws NullPointerException if the algorithm is null.
+     * @throws RuntimeException if there is an error in getting the algorithm type from the annotation.
+     */
+    public static boolean isLatentVariableAlgorithmByAnnotation(Algorithm algorithm) {
+        if (algorithm == null) {
+            throw new NullPointerException("Algorithm must not be null.");
+        }
+
+        Annotation annotation = algorithm.getClass().getAnnotationsByType(edu.cmu.tetrad.annotation.Algorithm.class)[0];
+
+        try {
+            Method method = annotation.annotationType().getDeclaredMethod("algoType");
+            AlgType ret = (AlgType) method.invoke(annotation);
+
+            if (ret == AlgType.allow_latent_common_causes) {
+                return true;
+            }
+        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+            throw new RuntimeException("Error in getting algorithm type from annotation", e);
+        }
+
+        return false;
     }
 
     /**

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/util/TaskRunner.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/util/TaskRunner.java
@@ -41,8 +41,8 @@ public class TaskRunner<T> {
     private final ExecutorService pool;
 
     /**
-     * This class is responsible for running a list of tasks that implement the Callable interface in parallel using
-     * multiple threads.
+     * This class is responsible for running a list of tasks that implement the
+     * Callable interface in parallel using multiple threads.
      */
     public TaskRunner() {
         this(Runtime.getRuntime().availableProcessors());
@@ -58,7 +58,8 @@ public class TaskRunner<T> {
     }
 
     /**
-     * Executes a list of tasks that implement Callable in parallel using multiple threads.
+     * Executes a list of tasks that implement Callable in parallel using
+     * multiple threads.
      *
      * @param tasks the list of tasks to execute
      * @return a list of results from the completed tasks
@@ -82,8 +83,10 @@ public class TaskRunner<T> {
             for (Future<T> completedTask : completedTasks) {
                 results.add(completedTask.get());
             }
-        } catch (ExecutionException | InterruptedException exception) {
+        } catch (InterruptedException exception) {
             LOGGER.error("", exception);
+        } catch (ExecutionException exception) {
+            throw new RuntimeException(exception.getCause().getMessage());
         }
 
         return results;
@@ -92,12 +95,15 @@ public class TaskRunner<T> {
     /**
      * Shuts down an ExecutorService and awaits its termination.
      * <p>
-     * This method gracefully shuts down the ExecutorService by calling {@link ExecutorService#shutdown()} and then
-     * waits for the termination of all tasks for a specified timeout period using the
-     * {@link ExecutorService#awaitTermination(long, TimeUnit)} method. If the tasks do not terminate within the timeout
-     * period, the method forcefully shuts down the ExecutorService by calling {@link ExecutorService#shutdownNow()} and
-     * waits again for the termination using {@link ExecutorService#awaitTermination(long, TimeUnit)}. If the tasks
-     * still do not terminate, an error message is logged.
+     * This method gracefully shuts down the ExecutorService by calling
+     * {@link ExecutorService#shutdown()} and then waits for the termination of
+     * all tasks for a specified timeout period using the
+     * {@link ExecutorService#awaitTermination(long, TimeUnit)} method. If the
+     * tasks do not terminate within the timeout period, the method forcefully
+     * shuts down the ExecutorService by calling
+     * {@link ExecutorService#shutdownNow()} and waits again for the termination
+     * using {@link ExecutorService#awaitTermination(long, TimeUnit)}. If the
+     * tasks still do not terminate, an error message is logged.
      *
      * @param pool the ExecutorService to shut down and await termination
      */


### PR DESCRIPTION
https://github.com/cmu-phil/tetrad/issues/1745

Added a check of the annotations of an algorithm to determine if the algorithm has been declared a LV algorithm.

Used this check to show PAG coloring in the search box for LV algorithms like FCI and for no other algorithms, since it doesn't apply to other graph types.

Fixed the PAG coloring menu item so it works with this update.

Took away the FCI edge type info button from other graph boxes, as the type of algorithm that generated the graph is not available there.