### PR TITLE
add IndTestChiSquare case

### DIFF
--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/MarkovCheck.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/MarkovCheck.java
@@ -233,11 +233,14 @@ public class MarkovCheck {
         // call pvalue function on each item, only include the non-null ones
         List<Double> pVals = new ArrayList<>();
         for (IndependenceFact f : facts) {
-            double pV;
+            Double pV;
             // For now, check if the test is FisherZ test.
             if (independenceTest instanceof IndTestFisherZ) {
                 pV = ((IndTestFisherZ)independenceTest).getPValue(f.getX(), f.getY(), f.getZ());
                 pVals.add(pV);
+            } else if (independenceTest instanceof IndTestChiSquare) {
+                pV = ((IndTestChiSquare)independenceTest).getPValue(f.getX(), f.getY(), f.getZ());
+                if (pV != null) pVals.add(pV);
             }
         }
         return pVals;


### PR DESCRIPTION
Since we introduced [#1755 ](https://github.com/cmu-phil/tetrad/pull/1755)
In `getLocalPValues` now we can also consider the case for `IndTestChiSquare` 