### PR TITLE
Adjacency and ArrowHead Precision and Recall for target node's Markov Blanket nodes

### DIFF
--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/MarkovCheck.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/MarkovCheck.java
@@ -273,22 +273,19 @@ public class MarkovCheck {
         return accepts_rejects;
     }
 
-    // TODO VBC: this method is in progress.
     public void getPrecisionAndRecallOnMarkovBlanketGraph(Node x, Graph estimatedGraph, Graph trueGraph) {
         // Lookup graph is the same structure as trueGraph's structure but node objects replaced by estimated graph nodes.
         Graph lookupGraph = GraphUtils.replaceNodes(trueGraph, estimatedGraph.getNodes());
-        // TODO VBC: a different naming once this method is completed.
-        Graph truexMBLookupGraph = GraphUtils.getMarkovBlanketSubgraphWithTargetNode(lookupGraph, x);
-        System.out.println("truexMBLookupGraph:" + truexMBLookupGraph);
+        Graph xMBLookupGraph = GraphUtils.getMarkovBlanketSubgraphWithTargetNode(lookupGraph, x);
+        System.out.println("xMBLookupGraph:" + xMBLookupGraph);
         Graph xMBEstimatedGraph = GraphUtils.getMarkovBlanketSubgraphWithTargetNode(estimatedGraph, x);
         System.out.println("xMBEstimatedGraph:" + xMBEstimatedGraph);
 
-
         // TODO VBC: validate
-        double ap = new AdjacencyPrecision().getValue(truexMBLookupGraph, xMBEstimatedGraph, null);
-        double ar = new AdjacencyRecall().getValue(truexMBLookupGraph, xMBEstimatedGraph, null);
-        double ahp = new ArrowheadPrecision().getValue(truexMBLookupGraph, xMBEstimatedGraph, null);
-        double ahr = new ArrowheadRecall().getValue(truexMBLookupGraph, xMBEstimatedGraph, null);
+        double ap = new AdjacencyPrecision().getValue(xMBLookupGraph, xMBEstimatedGraph, null);
+        double ar = new AdjacencyRecall().getValue(xMBLookupGraph, xMBEstimatedGraph, null);
+        double ahp = new ArrowheadPrecision().getValue(xMBLookupGraph, xMBEstimatedGraph, null);
+        double ahr = new ArrowheadRecall().getValue(xMBLookupGraph, xMBEstimatedGraph, null);
 
         NumberFormat nf = new DecimalFormat("0.00");
         System.out.println( "Node " + x + "'s statistics: " + " \n" +

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/MarkovCheck.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/MarkovCheck.java
@@ -1,5 +1,9 @@
 package edu.cmu.tetrad.search;
 
+import edu.cmu.tetrad.algcomparison.statistic.AdjacencyPrecision;
+import edu.cmu.tetrad.algcomparison.statistic.AdjacencyRecall;
+import edu.cmu.tetrad.algcomparison.statistic.ArrowheadPrecision;
+import edu.cmu.tetrad.algcomparison.statistic.ArrowheadRecall;
 import edu.cmu.tetrad.data.GeneralAndersonDarlingTest;
 import edu.cmu.tetrad.data.Knowledge;
 import edu.cmu.tetrad.graph.*;
@@ -270,42 +274,26 @@ public class MarkovCheck {
     }
 
     // TODO VBC: this method is in progress.
-    public Double getPrecisionOrRecallOnMarkovBlanketGraph(Node x, Graph estimatedGraph, Graph trueGraph, boolean getPrecision) {
+    public void getPrecisionAndRecallOnMarkovBlanketGraph(Node x, Graph estimatedGraph, Graph trueGraph) {
         // Lookup graph is the same structure as trueGraph's structure but node objects replaced by estimated graph nodes.
         Graph lookupGraph = GraphUtils.replaceNodes(trueGraph, estimatedGraph.getNodes());
         // TODO VBC: a different naming once this method is completed.
-        Graph RecommendedxMBLookupGraph = GraphUtils.getMarkovBlanketSubgraphWithTargetNode(lookupGraph, x);
-//        System.out.println("RecommendedxMBLookupGraph:" + RecommendedxMBLookupGraph);
+        Graph truexMBLookupGraph = GraphUtils.getMarkovBlanketSubgraphWithTargetNode(lookupGraph, x);
+        System.out.println("truexMBLookupGraph:" + truexMBLookupGraph);
         Graph xMBEstimatedGraph = GraphUtils.getMarkovBlanketSubgraphWithTargetNode(estimatedGraph, x);
-//        System.out.println("xMBEstimatedGraph:" + xMBEstimatedGraph);
+        System.out.println("xMBEstimatedGraph:" + xMBEstimatedGraph);
 
-        HashSet<Edge> TP = new HashSet<>();
-        HashSet<Edge> TN = new HashSet<>();
-        HashSet<Edge> FP = new HashSet<>();
-        HashSet<Edge> FN = new HashSet<>();
-        Set<Edge> trueMBEdges = RecommendedxMBLookupGraph.getEdges();
-        Set<Edge> estMBEdges = xMBEstimatedGraph.getEdges();
-        if (trueMBEdges != null && estMBEdges != null) {
-            for (Edge te : trueMBEdges) {
-                for (Edge ee : estMBEdges) {
-                    // True Graph's Edge info
-                    Node teNode1 = te.getNode1();
-                    Node teNode2 = te.getNode1();
-                    Endpoint teEndpoint1 = te.getEndpoint1();
-                    Endpoint teEndpoint2 = te.getEndpoint2();
-                    // Estimated Graph's Edge info
-                    Node eeNode1 = te.getNode1();
-                    Node eeNode2 = te.getNode1();
-                    Endpoint eeEndpoint1 = ee.getEndpoint1();
-                    Endpoint eeEndpoint2 = ee.getEndpoint2();
-                    // TODO VBC: calculate precision and recall for AH and Adj.
-                }
-            }
-        }
-        // TODO VBC: need both for AH and Adj, so this getPrecision way need further fix to fit UI later.
-        double precision = (double) TP.size() / (TP.size() + FP.size());
-        double recall = (double) TP.size() / (TP.size() + FN.size());
-        return getPrecision ? precision : recall;
+
+        // TODO VBC: validate
+        double ap = new AdjacencyPrecision().getValue(truexMBLookupGraph, xMBEstimatedGraph, null);
+        double ar = new AdjacencyRecall().getValue(truexMBLookupGraph, xMBEstimatedGraph, null);
+        double ahp = new ArrowheadPrecision().getValue(truexMBLookupGraph, xMBEstimatedGraph, null);
+        double ahr = new ArrowheadRecall().getValue(truexMBLookupGraph, xMBEstimatedGraph, null);
+
+        NumberFormat nf = new DecimalFormat("0.00");
+        System.out.println( "Node " + x + "'s statistics: " + " \n" +
+                " AdjPrecision = " + nf.format(ap) + " AdjRecall = " + nf.format(ar) + " \n" +
+                " ArrowHeadPrecision = " + nf.format(ahp) + " ArrowHeadRecall = " + nf.format(ahr));
     }
 
     /**

--- a/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestCheckMarkov.java
+++ b/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestCheckMarkov.java
@@ -117,8 +117,8 @@ public class TestCheckMarkov {
     public void testPrecissionRecallForLocal() {
         // TODO VBC: next I also use randome graph that is converted to CPDag then have a diff test case for that.
         Graph trueGraph = RandomGraph.randomDag(10, 0, 10, 100, 100, 100, false);
-//        System.out.println("Test True Graph: " + trueGraph);
-//        System.out.println("Test True Graph size: " + trueGraph.getNodes().size());
+        System.out.println("Test True Graph: " + trueGraph);
+        System.out.println("Test True Graph size: " + trueGraph.getNodes().size());
 
         SemPm pm = new SemPm(trueGraph);
         SemIm im = new SemIm(pm, new Parameters());
@@ -126,7 +126,8 @@ public class TestCheckMarkov {
         edu.cmu.tetrad.search.score.SemBicScore score = new SemBicScore(data, false);
         score.setPenaltyDiscount(2);
         Graph estimatedCpdag = new PermutationSearch(new Boss(score)).search();
-//        System.out.println("Test Estimated CPDAG Graph: " + estimatedCpdag);
+        System.out.println("Test Estimated CPDAG Graph: " + estimatedCpdag);
+        System.out.println("~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
 
         IndependenceTest fisherZTest = new IndTestFisherZ(data, 0.05);
         MarkovCheck markovCheck = new MarkovCheck(estimatedCpdag, fisherZTest, ConditioningSetType.MARKOV_BLANKET);
@@ -139,14 +140,11 @@ public class TestCheckMarkov {
         List<Double> acceptsPrecision = new ArrayList<>();
         List<Double> acceptsRecall = new ArrayList<>();
         for(Node a: accepts) {
-            // TODO VBC: these two are current placeholders. Will provide Precision and Recall for both Adj and AH in following Pull Request.
-            double precision = markovCheck.getPrecisionOrRecallOnMarkovBlanketGraph(a, estimatedCpdag, trueGraph, true);
-            double recall = markovCheck.getPrecisionOrRecallOnMarkovBlanketGraph(a, estimatedCpdag, trueGraph, false);
-            acceptsPrecision.add(precision);
-            acceptsRecall.add(recall);
+            System.out.println("=====================");
+            markovCheck.getPrecisionAndRecallOnMarkovBlanketGraph(a, estimatedCpdag, trueGraph);
+            System.out.println("=====================");
+
         }
         // TODO VBC: for rejects.
-        System.out.println("Accepts Precisions: " + acceptsPrecision);
-        System.out.println("Accepts Recall: " + acceptsRecall);
     }
 }

--- a/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestCheckMarkov.java
+++ b/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestCheckMarkov.java
@@ -145,6 +145,10 @@ public class TestCheckMarkov {
             System.out.println("=====================");
 
         }
-        // TODO VBC: for rejects.
+        for (Node a: rejects) {
+            System.out.println("=====================");
+            markovCheck.getPrecisionAndRecallOnMarkovBlanketGraph(a, estimatedCpdag, trueGraph);
+            System.out.println("=====================");
+        }
     }
 }


### PR DESCRIPTION
target node's Markov Blanket nodes can either be accepted or rejected by Anderson-Darling Test against Uniform Distribution. This Pull Request used the existing `AdjacencyPrecision`, `AdjacencyRecall`, `ArrowheadPrecision`, `ArrowheadRecall` logic to calculated statistical values of these accepted/rejected nodes. 

Sample output 1: 
```
Test True Graph: Graph Nodes:
X1;X2;X3;X4;X5;X6;X7;X8;X9;X10

Graph Edges:
1. X1 --> X6
2. X1 --> X9
3. X1 --> X10
4. X2 --> X3
5. X3 --> X6
6. X3 --> X7
7. X3 --> X10
8. X4 --> X5
9. X6 --> X7
10. X7 --> X9


Test True Graph size: 10
Test Estimated CPDAG Graph: Graph Nodes:
X1;X2;X3;X4;X5;X6;X7;X8;X9;X10

Graph Edges:
1. X1 --> X6
2. X1 --> X9
3. X1 --> X10
4. X2 --- X3
5. X3 --> X6
6. X3 --> X7
7. X3 --> X10
8. X4 --- X5
9. X6 --> X7
10. X7 --> X9


~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Accepts size: 2
Rejects size: 8
=====================
xMBLookupGraph:Graph Nodes:
X2;X3

Graph Edges:
1. X2 --> X3


xMBEstimatedGraph:Graph Nodes:
X2;X3

Graph Edges:
1. X2 --- X3


Node X2's statistics:  
 AdjPrecision = 1.00 AdjRecall = 1.00 
 ArrowHeadPrecision = NaN ArrowHeadRecall = 0.00
=====================
=====================
xMBLookupGraph:Graph Nodes:
X8

Graph Edges:


xMBEstimatedGraph:Graph Nodes:
X8

Graph Edges:


Node X8's statistics:  
 AdjPrecision = NaN AdjRecall = NaN 
 ArrowHeadPrecision = NaN ArrowHeadRecall = NaN
=====================
=====================
xMBLookupGraph:Graph Nodes:
X9;X10;X1;X3;X6;X7

Graph Edges:
1. X1 --> X6
2. X1 --> X9
3. X1 --> X10
4. X3 --> X6
5. X3 --> X7
6. X3 --> X10
7. X6 --> X7
8. X7 --> X9


xMBEstimatedGraph:Graph Nodes:
X9;X10;X1;X3;X6;X7

Graph Edges:
1. X1 --> X6
2. X1 --> X9
3. X1 --> X10
4. X3 --> X6
5. X3 --> X7
6. X3 --> X10
7. X6 --> X7
8. X7 --> X9


Node X1's statistics:  
 AdjPrecision = 1.00 AdjRecall = 1.00 
 ArrowHeadPrecision = 1.00 ArrowHeadRecall = 1.00
=====================
=====================
xMBLookupGraph:Graph Nodes:
X10;X1;X2;X3;X6;X7

Graph Edges:
1. X1 --> X6
2. X1 --> X10
3. X2 --> X3
4. X3 --> X6
5. X3 --> X7
6. X3 --> X10
7. X6 --> X7


xMBEstimatedGraph:Graph Nodes:
X10;X1;X2;X3;X6;X7

Graph Edges:
1. X1 --> X6
2. X1 --> X10
3. X2 --- X3
4. X3 --> X6
5. X3 --> X7
6. X3 --> X10
7. X6 --> X7


Node X3's statistics:  
 AdjPrecision = 1.00 AdjRecall = 1.00 
 ArrowHeadPrecision = 1.00 ArrowHeadRecall = 0.86
=====================
=====================
xMBLookupGraph:Graph Nodes:
X4;X5

Graph Edges:
1. X4 --> X5


xMBEstimatedGraph:Graph Nodes:
X4;X5

Graph Edges:
1. X4 --- X5


Node X4's statistics:  
 AdjPrecision = 1.00 AdjRecall = 1.00 
 ArrowHeadPrecision = NaN ArrowHeadRecall = 0.00
=====================
=====================
xMBLookupGraph:Graph Nodes:
X4;X5

Graph Edges:
1. X4 --> X5


xMBEstimatedGraph:Graph Nodes:
X4;X5

Graph Edges:
1. X4 --- X5


Node X5's statistics:  
 AdjPrecision = 1.00 AdjRecall = 1.00 
 ArrowHeadPrecision = NaN ArrowHeadRecall = 0.00
=====================
=====================
xMBLookupGraph:Graph Nodes:
X1;X3;X6;X7

Graph Edges:
1. X1 --> X6
2. X3 --> X6
3. X3 --> X7
4. X6 --> X7


xMBEstimatedGraph:Graph Nodes:
X1;X3;X6;X7

Graph Edges:
1. X1 --> X6
2. X3 --> X6
3. X3 --> X7
4. X6 --> X7


Node X6's statistics:  
 AdjPrecision = 1.00 AdjRecall = 1.00 
 ArrowHeadPrecision = 1.00 ArrowHeadRecall = 1.00
=====================
=====================
xMBLookupGraph:Graph Nodes:
X9;X1;X3;X6;X7

Graph Edges:
1. X1 --> X6
2. X1 --> X9
3. X3 --> X6
4. X3 --> X7
5. X6 --> X7
6. X7 --> X9


xMBEstimatedGraph:Graph Nodes:
X9;X1;X3;X6;X7

Graph Edges:
1. X1 --> X6
2. X1 --> X9
3. X3 --> X6
4. X3 --> X7
5. X6 --> X7
6. X7 --> X9


Node X7's statistics:  
 AdjPrecision = 1.00 AdjRecall = 1.00 
 ArrowHeadPrecision = 1.00 ArrowHeadRecall = 1.00
=====================
=====================
xMBLookupGraph:Graph Nodes:
X9;X1;X7

Graph Edges:
1. X1 --> X9
2. X7 --> X9


xMBEstimatedGraph:Graph Nodes:
X9;X1;X7

Graph Edges:
1. X1 --> X9
2. X7 --> X9


Node X9's statistics:  
 AdjPrecision = 1.00 AdjRecall = 1.00 
 ArrowHeadPrecision = 1.00 ArrowHeadRecall = 1.00
=====================
=====================
xMBLookupGraph:Graph Nodes:
X10;X1;X3

Graph Edges:
1. X1 --> X10
2. X3 --> X10


xMBEstimatedGraph:Graph Nodes:
X10;X1;X3

Graph Edges:
1. X1 --> X10
2. X3 --> X10


Node X10's statistics:  
 AdjPrecision = 1.00 AdjRecall = 1.00 
 ArrowHeadPrecision = 1.00 ArrowHeadRecall = 1.00
=====================

Process finished with exit code 0

```

Sample output 2: 
```
Test True Graph: Graph Nodes:
X1;X2;X3;X4;X5;X6;X7;X8;X9;X10

Graph Edges:
1. X2 --> X3
2. X2 --> X8
3. X2 --> X10
4. X3 --> X4
5. X3 --> X5
6. X3 --> X8
7. X4 --> X9
8. X8 --> X9
9. X8 --> X10
10. X9 --> X10


Test True Graph size: 10
Test Estimated CPDAG Graph: Graph Nodes:
X1;X2;X3;X4;X5;X6;X7;X8;X9;X10

Graph Edges:
1. X2 --> X3
2. X2 --> X10
3. X3 --> X5
4. X4 --> X3
5. X9 --> X8
6. X9 --> X10
7. X10 --> X8


~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Accepts size: 2
Rejects size: 8
=====================
truexMBLookupGraph:Graph Nodes:
X1

Graph Edges:


xMBEstimatedGraph:Graph Nodes:
X1

Graph Edges:


Node X1's statistics:  
 AdjPrecision = NaN AdjRecall = NaN 
 ArrowHeadPrecision = NaN ArrowHeadRecall = NaN
=====================
=====================
truexMBLookupGraph:Graph Nodes:
X8;X2;X3;X4;X5

Graph Edges:
1. X2 --> X3
2. X2 --> X8
3. X3 --> X4
4. X3 --> X5
5. X3 --> X8


xMBEstimatedGraph:Graph Nodes:
X2;X3;X4;X5

Graph Edges:
1. X2 --> X3
2. X3 --> X5
3. X4 --> X3


Node X3's statistics:  
 AdjPrecision = 1.00 AdjRecall = 0.60 
 ArrowHeadPrecision = 0.67 ArrowHeadRecall = 0.40
=====================

Process finished with exit code 0

```