### PR TITLE
Generate plot data for Gaussian CPDAG Markov Blanket case using AdjP, AdjR, AHP, AHR confusion statistics

### DIFF
--- a/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestCheckMarkov.java
+++ b/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestCheckMarkov.java
@@ -161,24 +161,13 @@ public class TestCheckMarkov {
         IndependenceTest fisherZTest = new IndTestFisherZ(data, 0.05);
         MarkovCheck markovCheck = new MarkovCheck(estimatedCpdag, fisherZTest, ConditioningSetType.MARKOV_BLANKET);
         // ADTest pass/fail threshold default to be 0.05. shuffleThreshold default to be 0.5
-        List<List<Node>> accepts_rejects = markovCheck.getAndersonDarlingTestAcceptsRejectsNodesForAllNodes(fisherZTest, estimatedCpdag, 0.05, 0.5);
+//        List<List<Node>> accepts_rejects = markovCheck.getAndersonDarlingTestAcceptsRejectsNodesForAllNodes(fisherZTest, estimatedCpdag, 0.05, 0.5);
+        List<List<Node>> accepts_rejects = markovCheck.getAndersonDarlingTestAcceptsRejectsNodesForAllNodesPlotData(fisherZTest, estimatedCpdag, trueGraph, 0.05, 0.3);
+
         List<Node> accepts = accepts_rejects.get(0);
         List<Node> rejects = accepts_rejects.get(1);
         System.out.println("Accepts size: " + accepts.size());
         System.out.println("Rejects size: " + rejects.size());
-
-        // Compare the Est CPDAG with True graph's CPDAG.
-        for(Node a: accepts) {
-            System.out.println("=====================");
-            markovCheck.getPrecisionAndRecallOnMarkovBlanketGraph(a, estimatedCpdag, trueGraphCPDAG);
-            System.out.println("=====================");
-
-        }
-        for (Node a: rejects) {
-            System.out.println("=====================");
-            markovCheck.getPrecisionAndRecallOnMarkovBlanketGraph(a, estimatedCpdag, trueGraphCPDAG);
-            System.out.println("=====================");
-        }
     }
 
     @Test


### PR DESCRIPTION
Confusion statistics were calculated using Adjacency (AdjacencyPrecision, AdjacencyRecall) and Arrowhead (ArrowheadPrecision, ArrowheadRecall)

Sample output `accepts_AdjP_ADTestP_data.csv`: 
```
1.00,0.11
1.00,0.64
1.00,0.26
1.00,0.67
1.00,0.31
1.00,0.08
1.00,0.06
1.00,0.22
1.00,0.20
1.00,0.06
1.00,0.23
1.00,0.22
1.00,0.21
1.00,0.31
1.00,0.27
1.00,0.07
1.00,0.39
1.00,0.05
1.00,0.61
1.00,0.28
1.00,0.05

```