### PR TITLE
Introduce test and plot data collection for Gaussian CPDAG case for local Markov Blanket using Local Graph Confusion statistics

### DIFF
--- a/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestCheckMarkov.java
+++ b/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestCheckMarkov.java
@@ -470,4 +470,34 @@ public class TestCheckMarkov {
         System.out.println("Rejects size: " + rejects.size());
     }
 
+    @Test
+    public void testGaussianCPDAGPrecisionRecallForLocalOnMarkovBlanket2() {
+        Graph trueGraph = RandomGraph.randomDag(10, 0, 10, 100, 100, 100, false);
+        // The completed partially directed acyclic graph (CPDAG) for the given DAG.
+        Graph trueGraphCPDAG = GraphTransforms.dagToCpdag(trueGraph);
+        System.out.println("Test True Graph: " + trueGraph);
+        System.out.println("Test True Graph CPDAG: " + trueGraphCPDAG);
+
+        SemPm pm = new SemPm(trueGraph);
+        // Parameters without additional setting default tobe Gaussian
+        SemIm im = new SemIm(pm, new Parameters());
+        DataSet data = im.simulateData(1000, false);
+        edu.cmu.tetrad.search.score.SemBicScore score = new SemBicScore(data, false);
+        score.setPenaltyDiscount(2);
+        Graph estimatedCpdag = new PermutationSearch(new Boss(score)).search();
+        System.out.println("Test Estimated CPDAG Graph: " + estimatedCpdag);
+        System.out.println("~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
+
+        IndependenceTest fisherZTest = new IndTestFisherZ(data, 0.05);
+        MarkovCheck markovCheck = new MarkovCheck(estimatedCpdag, fisherZTest, ConditioningSetType.MARKOV_BLANKET);
+        // ADTest pass/fail threshold default to be 0.05. shuffleThreshold default to be 0.5
+//        List<List<Node>> accepts_rejects = markovCheck.getAndersonDarlingTestAcceptsRejectsNodesForAllNodes2(fisherZTest, estimatedCpdag, 0.05, 0.5);
+        List<List<Node>> accepts_rejects = markovCheck.getAndersonDarlingTestAcceptsRejectsNodesForAllNodesPlotData2(fisherZTest, estimatedCpdag, trueGraph, 0.05, 0.3);
+
+        List<Node> accepts = accepts_rejects.get(0);
+        List<Node> rejects = accepts_rejects.get(1);
+        System.out.println("Accepts size: " + accepts.size());
+        System.out.println("Rejects size: " + rejects.size());
+    }
+
 }


### PR DESCRIPTION
Introduce test and plot data collection for Gaussian CPDAG case for local Markov Blanket using Local Graph Confusion statistics. 
Confusion statistics were calculated using Local Graph Precision and Recall (`LocalGraphPrecision`, `LocalGraphRecall`).

Sample output `accepts_LGP_ADTestP_data.csv`: 
```
1.00,0.43
1.00,0.08
1.00,0.06
1.00,0.05
1.00,0.08
1.00,0.26
1.00,0.09
1.00,0.07
1.00,0.08
1.00,0.20
1.00,0.05
1.00,0.12
1.00,0.12
1.00,0.08
1.00,0.26
1.00,0.20
1.00,0.11
1.00,0.13

```