### PR TITLE
Non Gaussian DAG/CPDAG for Local Markov Blanket test case, confusion stats using LocalGraphConfusion

### DIFF
--- a/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestCheckMarkov.java
+++ b/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestCheckMarkov.java
@@ -489,4 +489,36 @@ public class TestCheckMarkov {
         System.out.println("Rejects size: " + rejects.size());
     }
 
+    @Test
+    public void testNonGaussianDAGPrecisionRecallForLocalOnMarkovBlanket2() {
+        Graph trueGraph = RandomGraph.randomDag(10, 0, 10, 100, 100, 100, false);
+        System.out.println("Test True Graph: " + trueGraph);
+        System.out.println("Test True Graph size: " + trueGraph.getNodes().size());
+
+        SemPm pm = new SemPm(trueGraph);
+
+        Parameters params = new Parameters();
+        // Manually set non-Gaussian
+        params.set(Params.SIMULATION_ERROR_TYPE, 3);
+        params.set(Params.SIMULATION_PARAM1, 1);
+
+        SemIm im = new SemIm(pm, params);
+        DataSet data = im.simulateData(1000, false);
+        edu.cmu.tetrad.search.score.SemBicScore score = new SemBicScore(data, false);
+        score.setPenaltyDiscount(2);
+        Graph estimatedCpdag = new PermutationSearch(new Boss(score)).search();
+        System.out.println("Test Estimated CPDAG Graph: " + estimatedCpdag);
+        System.out.println("~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
+
+        IndependenceTest fisherZTest = new IndTestFisherZ(data, 0.05);
+        MarkovCheck markovCheck = new MarkovCheck(estimatedCpdag, fisherZTest, ConditioningSetType.MARKOV_BLANKET);
+        // ADTest pass/fail threshold default to be 0.05. shuffleThreshold default to be 0.5
+        //        List<List<Node>> accepts_rejects = markovCheck.getAndersonDarlingTestAcceptsRejectsNodesForAllNodes2(fisherZTest, estimatedCpdag, 0.05, 0.3);
+        List<List<Node>> accepts_rejects = markovCheck.getAndersonDarlingTestAcceptsRejectsNodesForAllNodesPlotData2(fisherZTest, estimatedCpdag, trueGraph, 0.05, 0.3);
+        List<Node> accepts = accepts_rejects.get(0);
+        List<Node> rejects = accepts_rejects.get(1);
+        System.out.println("Accepts size: " + accepts.size());
+        System.out.println("Rejects size: " + rejects.size());
+    }
+
 }

--- a/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestCheckMarkov.java
+++ b/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestCheckMarkov.java
@@ -521,4 +521,37 @@ public class TestCheckMarkov {
         System.out.println("Rejects size: " + rejects.size());
     }
 
+    @Test
+    public void testNonGaussianCPDAGPrecisionRecallForLocalOnMarkovBlanket2() {
+        Graph trueGraph = RandomGraph.randomDag(10, 0, 10, 100, 100, 100, false);
+        // The completed partially directed acyclic graph (CPDAG) for the given DAG.
+        Graph trueGraphCPDAG = GraphTransforms.dagToCpdag(trueGraph);
+        System.out.println("Test True Graph: " + trueGraph);
+        System.out.println("Test True Graph CPDAG: " + trueGraphCPDAG);
+
+        SemPm pm = new SemPm(trueGraph);
+
+        Parameters params = new Parameters();
+        // Manually set non-Gaussian
+        params.set(Params.SIMULATION_ERROR_TYPE, 3);
+        params.set(Params.SIMULATION_PARAM1, 1);
+
+        SemIm im = new SemIm(pm, params);
+        DataSet data = im.simulateData(1000, false);
+        edu.cmu.tetrad.search.score.SemBicScore score = new SemBicScore(data, false);
+        score.setPenaltyDiscount(2);
+        Graph estimatedCpdag = new PermutationSearch(new Boss(score)).search();
+        System.out.println("Test Estimated CPDAG Graph: " + estimatedCpdag);
+        System.out.println("~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
+
+        IndependenceTest fisherZTest = new IndTestFisherZ(data, 0.05);
+        MarkovCheck markovCheck = new MarkovCheck(estimatedCpdag, fisherZTest, ConditioningSetType.MARKOV_BLANKET);
+        // ADTest pass/fail threshold default to be 0.05. shuffleThreshold default to be 0.5
+        //        List<List<Node>> accepts_rejects = markovCheck.getAndersonDarlingTestAcceptsRejectsNodesForAllNodes2(fisherZTest, estimatedCpdag, 0.05, 0.5);
+        List<List<Node>> accepts_rejects = markovCheck.getAndersonDarlingTestAcceptsRejectsNodesForAllNodesPlotData2(fisherZTest, estimatedCpdag, trueGraph, 0.05, 0.3);
+        List<Node> accepts = accepts_rejects.get(0);
+        List<Node> rejects = accepts_rejects.get(1);
+        System.out.println("Accepts size: " + accepts.size());
+        System.out.println("Rejects size: " + rejects.size());
+    }
 }


### PR DESCRIPTION
Non Gaussian DAG/CPDAG for Local Markov Blanket test case, confusion stats using `LocalGraphConfusion` (LocalGraphPrecision, LocalGraphRecall). 

Sample output for `testNonGaussianDAGPrecisionRecallForLocalOnMarkovBlanket2`'s `accepts_LGP_ADTestP_data.csv`: 

```
1.00,0.05
1.00,0.14
1.00,0.25
1.00,0.06
1.00,0.05
1.00,0.46
1.00,0.23
1.00,0.10
1.00,0.06
1.00,0.07
1.00,0.28
1.00,0.49
1.00,0.22
1.00,0.16
1.00,0.31
1.00,0.28
1.00,0.32
1.00,0.06
1.00,0.37
1.00,0.05
1.00,0.09
1.00,0.22
1.00,0.10
1.00,0.28

```