### PR TITLE
Fixed shuffle function and combine all shuffled independence test p vals  for a target node into a flat list to feed into Anderson Darling Test

### DIFF
--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/MarkovCheck.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/MarkovCheck.java
@@ -28,6 +28,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.Future;
+import java.util.stream.Collectors;
 
 /**
  * Checks whether a graph is Markov given a data set. First, a list of m-separation predictions are made for each pair
@@ -327,13 +328,15 @@ public class MarkovCheck {
             List<IndependenceFact> localIndependenceFacts = getLocalIndependenceFacts(x);
             // All local nodes' p-values for node x
             List<List<Double>> shuffledlocalPValues = getLocalPValues(independenceTest, localIndependenceFacts, shuffleThreshold);
-            for (List<Double> localPValues: shuffledlocalPValues) {
-                Double ADTest = checkAgainstAndersonDarlingTest(localPValues); // P value obtained from AD test
-                if (ADTest <= threshold) {
-                    rejects.add(x);
-                } else {
-                    accepts.add(x);
-                }
+            // TODO VBC: what should we do for cases when ADTest is NaN and ∞ ?
+            List<Double> flatList = shuffledlocalPValues.stream()
+                    .flatMap(List::stream)
+                    .collect(Collectors.toList());
+            Double ADTestPValue = checkAgainstAndersonDarlingTest(flatList);
+            if (ADTestPValue <= threshold) {
+                rejects.add(x);
+            } else {
+                accepts.add(x);
             }
         }
         accepts_rejects.add(accepts);
@@ -391,38 +394,38 @@ public class MarkovCheck {
             Double ahr = ap_ar_ahp_ahr.get(3);
             // All local nodes' p-values for node x.
             List<List<Double>> shuffledlocalPValues = getLocalPValues(independenceTest, localIndependenceFacts, shuffleThreshold); // shuffleThreshold default to be 0.5
-            for (List<Double> localPValues: shuffledlocalPValues) {
-                // P value obtained from AD test
-                Double ADTestPValue = checkAgainstAndersonDarlingTest(localPValues);
-                // TODO VBC: what should we do for cases when ADTest is NaN and ∞ ?
-                if (ADTestPValue <= threshold) {
-                    rejects.add(x);
-                    if (!Double.isNaN(ap)) {
-                        rejects_AdjP_ADTestP.add(Arrays.asList(ap, ADTestPValue));
-                    }
-                    if (!Double.isNaN(ar)) {
-                        rejects_AdjR_ADTestP.add(Arrays.asList(ap, ADTestPValue));
-                    }
-                    if (!Double.isNaN(ahp)) {
-                        rejects_AHP_ADTestP.add(Arrays.asList(ap, ADTestPValue));
-                    }
-                    if (!Double.isNaN(ahr)) {
-                        rejects_AHR_ADTestP.add(Arrays.asList(ap, ADTestPValue));
-                    }
-                } else {
-                    accepts.add(x);
-                    if (!Double.isNaN(ap)) {
-                        accepts_AdjP_ADTestP.add(Arrays.asList(ap, ADTestPValue));
-                    }
-                    if (!Double.isNaN(ar)) {
-                        accepts_AdjR_ADTestP.add(Arrays.asList(ap, ADTestPValue));
-                    }
-                    if (!Double.isNaN(ahp)) {
-                        accepts_AHP_ADTestP.add(Arrays.asList(ap, ADTestPValue));
-                    }
-                    if (!Double.isNaN(ahr)) {
-                        accepts_AHR_ADTestP.add(Arrays.asList(ap, ADTestPValue));
-                    }
+            List<Double> flatList = shuffledlocalPValues.stream()
+                    .flatMap(List::stream)
+                    .collect(Collectors.toList());
+            Double ADTestPValue = checkAgainstAndersonDarlingTest(flatList);
+            // TODO VBC: what should we do for cases when ADTest is NaN and ∞ ?
+            if (ADTestPValue <= threshold) {
+                rejects.add(x);
+                if (!Double.isNaN(ap)) {
+                    rejects_AdjP_ADTestP.add(Arrays.asList(ap, ADTestPValue));
+                }
+                if (!Double.isNaN(ar)) {
+                    rejects_AdjR_ADTestP.add(Arrays.asList(ap, ADTestPValue));
+                }
+                if (!Double.isNaN(ahp)) {
+                    rejects_AHP_ADTestP.add(Arrays.asList(ap, ADTestPValue));
+                }
+                if (!Double.isNaN(ahr)) {
+                    rejects_AHR_ADTestP.add(Arrays.asList(ap, ADTestPValue));
+                }
+            } else {
+                accepts.add(x);
+                if (!Double.isNaN(ap)) {
+                    accepts_AdjP_ADTestP.add(Arrays.asList(ap, ADTestPValue));
+                }
+                if (!Double.isNaN(ar)) {
+                    accepts_AdjR_ADTestP.add(Arrays.asList(ap, ADTestPValue));
+                }
+                if (!Double.isNaN(ahp)) {
+                    accepts_AHP_ADTestP.add(Arrays.asList(ap, ADTestPValue));
+                }
+                if (!Double.isNaN(ahr)) {
+                    accepts_AHR_ADTestP.add(Arrays.asList(ap, ADTestPValue));
                 }
             }
         }
@@ -532,26 +535,26 @@ public class MarkovCheck {
             Double lgr = lgp_lgr.get(1);
             // All local nodes' p-values for node x.
             List<List<Double>> shuffledlocalPValues = getLocalPValues(independenceTest, localIndependenceFacts, shuffleThreshold); // shuffleThreshold default to be 0.5
-            for (List<Double> localPValues: shuffledlocalPValues) {
-                // P value obtained from AD test
-                Double ADTestPValue = checkAgainstAndersonDarlingTest(localPValues);
-                // TODO VBC: what should we do for cases when ADTest is NaN and ∞ ?
-                if (ADTestPValue <= threshold) {
-                    rejects.add(x);
-                    if (!Double.isNaN(lgp)) {
-                        rejects_LGP_ADTestP.add(Arrays.asList(lgp, ADTestPValue));
-                    }
-                    if (!Double.isNaN(lgr)) {
-                        rejects_LGR_ADTestP.add(Arrays.asList(lgr, ADTestPValue));
-                    }
-                } else {
-                    accepts.add(x);
-                    if (!Double.isNaN(lgp)) {
-                        accepts_LGP_ADTestP.add(Arrays.asList(lgp, ADTestPValue));
-                    }
-                    if (!Double.isNaN(lgr)) {
-                        accepts_LGR_ADTestP.add(Arrays.asList(lgr, ADTestPValue));
-                    }
+            List<Double> flatList = shuffledlocalPValues.stream()
+                    .flatMap(List::stream)
+                    .collect(Collectors.toList());
+            Double ADTestPValue = checkAgainstAndersonDarlingTest(flatList);
+            // TODO VBC: what should we do for cases when ADTest is NaN and ∞ ?
+            if (ADTestPValue <= threshold) {
+                rejects.add(x);
+                if (!Double.isNaN(lgp)) {
+                    rejects_LGP_ADTestP.add(Arrays.asList(lgp, ADTestPValue));
+                }
+                if (!Double.isNaN(lgr)) {
+                    rejects_LGR_ADTestP.add(Arrays.asList(lgr, ADTestPValue));
+                }
+            } else {
+                accepts.add(x);
+                if (!Double.isNaN(lgp)) {
+                    accepts_LGP_ADTestP.add(Arrays.asList(lgp, ADTestPValue));
+                }
+                if (!Double.isNaN(lgr)) {
+                    accepts_LGR_ADTestP.add(Arrays.asList(lgr, ADTestPValue));
                 }
             }
         }

--- a/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestCheckMarkov.java
+++ b/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestCheckMarkov.java
@@ -113,9 +113,9 @@ public class TestCheckMarkov {
 
     @Test
     public void testGaussianDAGPrecisionRecallForLocalOnMarkovBlanket() {
-         Graph trueGraph = RandomGraph.randomDag(10, 0, 10, 100, 100, 100, false);
+//         Graph trueGraph = RandomGraph.randomDag(10, 0, 10, 100, 100, 100, false);
 //       TODO VBC: Also check different dense graph.
-//        Graph trueGraph = RandomGraph.randomDag(20, 0, 40, 100, 100, 100, false);
+        Graph trueGraph = RandomGraph.randomDag(20, 0, 40, 100, 100, 100, false);
         System.out.println("Test True Graph: " + trueGraph);
         System.out.println("Test True Graph size: " + trueGraph.getNodes().size());
 
@@ -133,7 +133,7 @@ public class TestCheckMarkov {
         IndependenceTest fisherZTest = new IndTestFisherZ(data, 0.05);
         MarkovCheck markovCheck = new MarkovCheck(estimatedCpdag, fisherZTest, ConditioningSetType.MARKOV_BLANKET);
 //        List<List<Node>> accepts_rejects = markovCheck.getAndersonDarlingTestAcceptsRejectsNodesForAllNodes(fisherZTest, estimatedCpdag, 0.05);
-        List<List<Node>> accepts_rejects = markovCheck.getAndersonDarlingTestAcceptsRejectsNodesForAllNodesPlotData(fisherZTest, estimatedCpdag, trueGraph, 0.05, 0.3);
+        List<List<Node>> accepts_rejects = markovCheck.getAndersonDarlingTestAcceptsRejectsNodesForAllNodesPlotData(fisherZTest, estimatedCpdag, trueGraph, 0.05, 0.5);
         List<Node> accepts = accepts_rejects.get(0);
         List<Node> rejects = accepts_rejects.get(1);
         System.out.println("Accepts size: " + accepts.size());


### PR DESCRIPTION
Shuffle function now fixed. 

When `shuffleThreshold = 1.0`, the number of independence test p vals is the same of amount as the total number of nodes in the whole graph. 
When `shuffleThreshold = 0.5`, the number of independence test p vals is the twice of amount as the total number of nodes in the whole graph. 

Then the flat list of combined total shuffled independence test p vals will be send into ADTest to get a ADTest P val for the target node. 
...
