### PR TITLE
Markov Check, record lower recall nodes when plotting data

### DIFF
--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/MarkovCheck.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/MarkovCheck.java
@@ -363,12 +363,14 @@ public class MarkovCheck {
      * @param shuffleThreshold The threshold value for shuffling the data.
      * @return A list containing two lists: the first list contains the accepted nodes and the second list contains the
      */
-    public List<List<Node>> getAndersonDarlingTestAcceptsRejectsNodesForAllNodesPlotData(IndependenceTest independenceTest, Graph estimatedCpdag, Graph trueGraph, Double threshold, Double shuffleThreshold) {
+    public List<List<Node>> getAndersonDarlingTestAcceptsRejectsNodesForAllNodesPlotData(IndependenceTest independenceTest, Graph estimatedCpdag, Graph trueGraph, Double threshold, Double shuffleThreshold, Double lowRecallBound) {
         // When calling, default reject null as <=0.05
-        List<List<Node>> accepts_rejects = new ArrayList<>();
+        List<List<Node>> accepts_rejects_lowRecalls = new ArrayList<>();
         List<Node> accepts = new ArrayList<>();
         List<Node> rejects = new ArrayList<>();
         List<Node> allNodes = graph.getNodes();
+        List<Node> lowAdjRecallNodes = new ArrayList<>();
+        List<Node> lowAHRecallNodes = new ArrayList<>();
 
         // Confusion stats lists for data processing.
         Map<String, String> fileContentMap = new HashMap<>();
@@ -391,6 +393,9 @@ public class MarkovCheck {
         fileContentMap.put("rejects_AHP_ADTestP_data.csv", "");
         fileContentMap.put("rejects_AHR_ADTestP_data.csv", "");
 
+        fileContentMap.put("lowAdjRecallNodes.csv", "");
+        fileContentMap.put("lowAHRecallNodes.csv", "");
+
         NumberFormat nf = new DecimalFormat("0.00");
         // Classify nodes into accepts and rejects base on ADTest result, and  update confusion stats lists accordingly.
         for (Node x : allNodes) {
@@ -401,6 +406,13 @@ public class MarkovCheck {
             Double ar = ap_ar_ahp_ahr.get(1);
             Double ahp = ap_ar_ahp_ahr.get(2);
             Double ahr = ap_ar_ahp_ahr.get(3);
+            // Record lower recall nodes
+            if (ar < lowRecallBound) {
+                lowAdjRecallNodes.add(x);
+            }
+            if (ahr < lowRecallBound) {
+                lowAHRecallNodes.add(x);
+            }
             // All local nodes' p-values for node x.
             List<List<Double>> shuffledlocalPValues = getLocalPValues(independenceTest, localIndependenceFacts, shuffleThreshold); // shuffleThreshold default to be 0.5
             List<Double> flatList = shuffledlocalPValues.stream()
@@ -439,8 +451,10 @@ public class MarkovCheck {
             }
             System.out.println("-----------------------------");
         }
-        accepts_rejects.add(accepts);
-        accepts_rejects.add(rejects);
+        accepts_rejects_lowRecalls.add(accepts);
+        accepts_rejects_lowRecalls.add(rejects);
+        accepts_rejects_lowRecalls.add(lowAdjRecallNodes);
+        accepts_rejects_lowRecalls.add(lowAHRecallNodes);
         // Write into data files.
         for (Map.Entry<String, String> entry : fileContentMap.entrySet()) {
             try (BufferedWriter writer = new BufferedWriter(new FileWriter(entry.getKey()))) {
@@ -493,6 +507,17 @@ public class MarkovCheck {
                             writer.write(nf.format(AHR_ADTestP_pair.get(0)) + "," + nf.format(AHR_ADTestP_pair.get(1)) + "\n");
                         }
                         break;
+                    case "lowAdjRecallNodes.csv":
+                        for (Node n : lowAdjRecallNodes) {
+                            writer.write(n.toString() + "\n");
+                        }
+                        break;
+                    case "lowAHRecallNodes.csv":
+                        for (Node n: lowAHRecallNodes) {
+                            writer.write(n.toString()+"\n");
+                        }
+                         break;
+
                     default:
                         break;
                 }
@@ -501,7 +526,7 @@ public class MarkovCheck {
                 e.printStackTrace();
             }
         }
-        return accepts_rejects;
+        return accepts_rejects_lowRecalls;
     }
 
     /**
@@ -518,12 +543,13 @@ public class MarkovCheck {
      * @param shuffleThreshold The threshold value for shuffling the data.
      * @return A list containing two lists: the first list contains the accepted nodes and the second list contains the
      */
-    public List<List<Node>> getAndersonDarlingTestAcceptsRejectsNodesForAllNodesPlotData2(IndependenceTest independenceTest, Graph estimatedCpdag, Graph trueGraph, Double threshold, Double shuffleThreshold) {
+    public List<List<Node>> getAndersonDarlingTestAcceptsRejectsNodesForAllNodesPlotData2(IndependenceTest independenceTest, Graph estimatedCpdag, Graph trueGraph, Double threshold, Double shuffleThreshold, Double lowRecallBound) {
         // When calling, default reject null as <=0.05
-        List<List<Node>> accepts_rejects = new ArrayList<>();
+        List<List<Node>> accepts_rejects_lowRecall = new ArrayList<>();
         List<Node> accepts = new ArrayList<>();
         List<Node> rejects = new ArrayList<>();
         List<Node> allNodes = graph.getNodes();
+        List<Node> lowLGRecallNodes = new ArrayList<>();
 
         // Confusion stats lists for data processing.
         Map<String, String> fileContentMap = new HashMap<>();
@@ -539,6 +565,8 @@ public class MarkovCheck {
         fileContentMap.put("rejects_LGP_ADTestP_data.csv", "");
         fileContentMap.put("rejects_LGR_ADTestP_data.csv", "");
 
+        fileContentMap.put("lowLGRecallNodes.csv", "");
+
         NumberFormat nf = new DecimalFormat("0.00");
         // Classify nodes into accepts and rejects base on ADTest result, and  update confusion stats lists accordingly.
         for (Node x : allNodes) {
@@ -547,6 +575,9 @@ public class MarkovCheck {
             List<Double> lgp_lgr = getPrecisionAndRecallOnMarkovBlanketGraphPlotData2(x, estimatedCpdag, trueGraph);
             Double lgp = lgp_lgr.get(0);
             Double lgr = lgp_lgr.get(1);
+            if (lgr < lowRecallBound) {
+                lowLGRecallNodes.add(x);
+            }
             // All local nodes' p-values for node x.
             List<List<Double>> shuffledlocalPValues = getLocalPValues(independenceTest, localIndependenceFacts, shuffleThreshold); // shuffleThreshold default to be 0.5
             List<Double> flatList = shuffledlocalPValues.stream()
@@ -574,8 +605,9 @@ public class MarkovCheck {
             }
             System.out.println("-----------------------------");
         }
-        accepts_rejects.add(accepts);
-        accepts_rejects.add(rejects);
+        accepts_rejects_lowRecall.add(accepts);
+        accepts_rejects_lowRecall.add(rejects);
+        accepts_rejects_lowRecall.add(lowLGRecallNodes);
         // Write into data files.
         for (Map.Entry<String, String> entry : fileContentMap.entrySet()) {
             try (BufferedWriter writer = new BufferedWriter(new FileWriter(entry.getKey()))) {
@@ -604,6 +636,11 @@ public class MarkovCheck {
                             writer.write(nf.format(LGR_ADTestP_pair.get(0)) + "," + nf.format(LGR_ADTestP_pair.get(1)) + "\n");
                         }
                         break;
+                    case "lowLGRecallNodes.csv":
+                        for (Node n: lowLGRecallNodes) {
+                            writer.write(n.toString()+"\n");
+                        }
+                        break;
 
                     default:
                         break;
@@ -613,7 +650,7 @@ public class MarkovCheck {
                 e.printStackTrace();
             }
         }
-        return accepts_rejects;
+        return accepts_rejects_lowRecall;
     }
 
     /**

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/MarkovCheck.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/MarkovCheck.java
@@ -361,6 +361,7 @@ public class MarkovCheck {
      * @param trueGraph        The true graph.
      * @param threshold        The threshold value for classifying nodes.
      * @param shuffleThreshold The threshold value for shuffling the data.
+     * @param lowRecallBound   The bound value for recording low recall.
      * @return A list containing two lists: the first list contains the accepted nodes and the second list contains the
      */
     public List<List<Node>> getAndersonDarlingTestAcceptsRejectsNodesForAllNodesPlotData(IndependenceTest independenceTest, Graph estimatedCpdag, Graph trueGraph, Double threshold, Double shuffleThreshold, Double lowRecallBound) {
@@ -541,6 +542,7 @@ public class MarkovCheck {
      * @param trueGraph        The true graph.
      * @param threshold        The threshold value for classifying nodes.
      * @param shuffleThreshold The threshold value for shuffling the data.
+     * @param lowRecallBound   The bound value for recording low recall.
      * @return A list containing two lists: the first list contains the accepted nodes and the second list contains the
      */
     public List<List<Node>> getAndersonDarlingTestAcceptsRejectsNodesForAllNodesPlotData2(IndependenceTest independenceTest, Graph estimatedCpdag, Graph trueGraph, Double threshold, Double shuffleThreshold, Double lowRecallBound) {

--- a/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestCheckMarkov.java
+++ b/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestCheckMarkov.java
@@ -114,7 +114,8 @@ public class TestCheckMarkov {
 
     @Test
     public void testGaussianDAGPrecisionRecallForLocalOnMarkovBlanket() {
-        Graph trueGraph = RandomGraph.randomDag(100, 0, 400, 100, 100, 100, false);
+//        Graph trueGraph = RandomGraph.randomDag(100, 0, 400, 100, 100, 100, false);
+        Graph trueGraph = RandomGraph.randomDag(10, 0, 40, 100, 100, 100, false);
         System.out.println("Test True Graph: " + trueGraph);
         System.out.println("Test True Graph size: " + trueGraph.getNodes().size());
 
@@ -150,7 +151,7 @@ public class TestCheckMarkov {
         IndependenceTest fisherZTest = new IndTestFisherZ(data, 0.05);
         MarkovCheck markovCheck = new MarkovCheck(estimatedCpdag, fisherZTest, ConditioningSetType.MARKOV_BLANKET);
         // Using Adj, AH confusion matrix
-        List<List<Node>> accepts_rejects = markovCheck.getAndersonDarlingTestAcceptsRejectsNodesForAllNodesPlotData(fisherZTest, estimatedCpdag, trueGraph, 0.05, 1.0);
+        List<List<Node>> accepts_rejects = markovCheck.getAndersonDarlingTestAcceptsRejectsNodesForAllNodesPlotData(fisherZTest, estimatedCpdag, trueGraph, 0.05, 1.0, 0.8);
         List<Node> accepts = accepts_rejects.get(0);
         List<Node> rejects = accepts_rejects.get(1);
         System.out.println("Accepts size: " + accepts.size());
@@ -162,7 +163,7 @@ public class TestCheckMarkov {
         MarkovCheck markovCheck = new MarkovCheck(estimatedCpdag, fisherZTest, ConditioningSetType.MARKOV_BLANKET);
         // Using Local Graph (LG) confusion matrix
         // ADTest pass/fail threshold default to be 0.05. shuffleThreshold default to be 0.5
-        List<List<Node>> accepts_rejects = markovCheck.getAndersonDarlingTestAcceptsRejectsNodesForAllNodesPlotData2(fisherZTest, estimatedCpdag, trueGraph, 0.05, 1.0);
+        List<List<Node>> accepts_rejects = markovCheck.getAndersonDarlingTestAcceptsRejectsNodesForAllNodesPlotData2(fisherZTest, estimatedCpdag, trueGraph, 0.05, 1.0, 0.8);
         List<Node> accepts = accepts_rejects.get(0);
         List<Node> rejects = accepts_rejects.get(1);
         System.out.println("Accepts size: " + accepts.size());
@@ -191,7 +192,7 @@ public class TestCheckMarkov {
         MarkovCheck markovCheck = new MarkovCheck(estimatedCpdag, fisherZTest, ConditioningSetType.MARKOV_BLANKET);
         // ADTest pass/fail threshold default to be 0.05. shuffleThreshold default to be 0.5
 //        List<List<Node>> accepts_rejects = markovCheck.getAndersonDarlingTestAcceptsRejectsNodesForAllNodes(fisherZTest, estimatedCpdag, 0.05, 0.5);
-        List<List<Node>> accepts_rejects = markovCheck.getAndersonDarlingTestAcceptsRejectsNodesForAllNodesPlotData(fisherZTest, estimatedCpdag, trueGraph, 0.05, 0.3);
+        List<List<Node>> accepts_rejects = markovCheck.getAndersonDarlingTestAcceptsRejectsNodesForAllNodesPlotData(fisherZTest, estimatedCpdag, trueGraph, 0.05, 0.3, 0.8);
 
         List<Node> accepts = accepts_rejects.get(0);
         List<Node> rejects = accepts_rejects.get(1);
@@ -224,7 +225,7 @@ public class TestCheckMarkov {
         MarkovCheck markovCheck = new MarkovCheck(estimatedCpdag, fisherZTest, ConditioningSetType.MARKOV_BLANKET);
         // ADTest pass/fail threshold default to be 0.05. shuffleThreshold default to be 0.5
         //        List<List<Node>> accepts_rejects = markovCheck.getAndersonDarlingTestAcceptsRejectsNodesForAllNodes(fisherZTest, estimatedCpdag, 0.05, 0.3);
-        List<List<Node>> accepts_rejects = markovCheck.getAndersonDarlingTestAcceptsRejectsNodesForAllNodesPlotData(fisherZTest, estimatedCpdag, trueGraph, 0.05, 0.3);
+        List<List<Node>> accepts_rejects = markovCheck.getAndersonDarlingTestAcceptsRejectsNodesForAllNodesPlotData(fisherZTest, estimatedCpdag, trueGraph, 0.05, 0.3, 0.8);
         List<Node> accepts = accepts_rejects.get(0);
         List<Node> rejects = accepts_rejects.get(1);
         System.out.println("Accepts size: " + accepts.size());
@@ -258,7 +259,7 @@ public class TestCheckMarkov {
         MarkovCheck markovCheck = new MarkovCheck(estimatedCpdag, fisherZTest, ConditioningSetType.MARKOV_BLANKET);
         // ADTest pass/fail threshold default to be 0.05. shuffleThreshold default to be 0.5
         //        List<List<Node>> accepts_rejects = markovCheck.getAndersonDarlingTestAcceptsRejectsNodesForAllNodes(fisherZTest, estimatedCpdag, 0.05, 0.5);
-        List<List<Node>> accepts_rejects = markovCheck.getAndersonDarlingTestAcceptsRejectsNodesForAllNodesPlotData(fisherZTest, estimatedCpdag, trueGraph, 0.05, 0.3);
+        List<List<Node>> accepts_rejects = markovCheck.getAndersonDarlingTestAcceptsRejectsNodesForAllNodesPlotData(fisherZTest, estimatedCpdag, trueGraph, 0.05, 0.3, 0.8);
         List<Node> accepts = accepts_rejects.get(0);
         List<Node> rejects = accepts_rejects.get(1);
         System.out.println("Accepts size: " + accepts.size());
@@ -459,7 +460,7 @@ public class TestCheckMarkov {
         MarkovCheck markovCheck = new MarkovCheck(estimatedCpdag, fisherZTest, ConditioningSetType.MARKOV_BLANKET);
         // ADTest pass/fail threshold default to be 0.05. shuffleThreshold default to be 0.5
 //        List<List<Node>> accepts_rejects = markovCheck.getAndersonDarlingTestAcceptsRejectsNodesForAllNodes2(fisherZTest, estimatedCpdag, 0.05, 0.5);
-        List<List<Node>> accepts_rejects = markovCheck.getAndersonDarlingTestAcceptsRejectsNodesForAllNodesPlotData2(fisherZTest, estimatedCpdag, trueGraph, 0.05, 0.3);
+        List<List<Node>> accepts_rejects = markovCheck.getAndersonDarlingTestAcceptsRejectsNodesForAllNodesPlotData2(fisherZTest, estimatedCpdag, trueGraph, 0.05, 0.3, 0.8);
 
         List<Node> accepts = accepts_rejects.get(0);
         List<Node> rejects = accepts_rejects.get(1);
@@ -492,7 +493,7 @@ public class TestCheckMarkov {
         MarkovCheck markovCheck = new MarkovCheck(estimatedCpdag, fisherZTest, ConditioningSetType.MARKOV_BLANKET);
         // ADTest pass/fail threshold default to be 0.05. shuffleThreshold default to be 0.5
         //        List<List<Node>> accepts_rejects = markovCheck.getAndersonDarlingTestAcceptsRejectsNodesForAllNodes2(fisherZTest, estimatedCpdag, 0.05, 0.3);
-        List<List<Node>> accepts_rejects = markovCheck.getAndersonDarlingTestAcceptsRejectsNodesForAllNodesPlotData2(fisherZTest, estimatedCpdag, trueGraph, 0.05, 0.3);
+        List<List<Node>> accepts_rejects = markovCheck.getAndersonDarlingTestAcceptsRejectsNodesForAllNodesPlotData2(fisherZTest, estimatedCpdag, trueGraph, 0.05, 0.3, 0.8);
         List<Node> accepts = accepts_rejects.get(0);
         List<Node> rejects = accepts_rejects.get(1);
         System.out.println("Accepts size: " + accepts.size());
@@ -526,7 +527,7 @@ public class TestCheckMarkov {
         MarkovCheck markovCheck = new MarkovCheck(estimatedCpdag, fisherZTest, ConditioningSetType.MARKOV_BLANKET);
         // ADTest pass/fail threshold default to be 0.05. shuffleThreshold default to be 0.5
         //        List<List<Node>> accepts_rejects = markovCheck.getAndersonDarlingTestAcceptsRejectsNodesForAllNodes2(fisherZTest, estimatedCpdag, 0.05, 0.5);
-        List<List<Node>> accepts_rejects = markovCheck.getAndersonDarlingTestAcceptsRejectsNodesForAllNodesPlotData2(fisherZTest, estimatedCpdag, trueGraph, 0.05, 0.3);
+        List<List<Node>> accepts_rejects = markovCheck.getAndersonDarlingTestAcceptsRejectsNodesForAllNodesPlotData2(fisherZTest, estimatedCpdag, trueGraph, 0.05, 0.3, 0.8);
         List<Node> accepts = accepts_rejects.get(0);
         List<Node> rejects = accepts_rejects.get(1);
         System.out.println("Accepts size: " + accepts.size());


### PR DESCRIPTION
Introduce a hard coded value of `lowRecallBound` for functions: `getAndersonDarlingTestAcceptsRejectsNodesForAllNodesPlotData(fisherZTest, estimatedCpdag, trueGraph, 0.05, 1.0, 0.8) `
and 
`getAndersonDarlingTestAcceptsRejectsNodesForAllNodesPlotData2(fisherZTest, estimatedCpdag, trueGraph, 0.05, 1.0, 0.8) `
the examples above are setting the low recall bound as 0.8, which means all the low recalls strictly lower than this value would be recorded as a seperate list. The low record nodes are recorded in: 
`lowAdjRecallNodes.csv` , `lowAHRecallNodes.csv`, `lowLGRecallNodes.csv`

