### PR TITLE
Update LocalGraph Confusion matrix calculation

### DIFF
--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/statistic/utils/LocalGraphConfusion.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/statistic/utils/LocalGraphConfusion.java
@@ -95,7 +95,7 @@ public class LocalGraphConfusion {
          *    Est     | --------------------------
          *         <- |   FP, FN     TP         /
          *            | --------------------------
-         *         -- |   FN         FN         /
+         *         -- |   0         0           /       (0 means unknown, do nothing)
          *            | --------------------------
          *         ...|    /         /          /
          *           -----------------------------
@@ -145,7 +145,7 @@ public class LocalGraphConfusion {
                         // this.fp++;
                         this.fn++;
                     } else if (ep1Est == Endpoint.TAIL && ep2Est == Endpoint.TAIL) { // Est: --
-                        this.fn++;
+                        // -- means Unknown, do nothing
                     }
                 } else if (ep1True == Endpoint.ARROW && ep2True == Endpoint.TAIL) { // True: <-
                     if (ep1Est == Endpoint.TAIL && ep2Est == Endpoint.ARROW) { // Est: ->
@@ -154,7 +154,7 @@ public class LocalGraphConfusion {
                     } else if (ep1Est == Endpoint.ARROW && ep2Est == Endpoint.TAIL) { // Est: <-
                         this.tp++;
                     } else if (ep1Est == Endpoint.TAIL && ep2Est == Endpoint.TAIL) { // Est: --
-                        this.fn++;
+                        // -- means Unknown, do nothing
                     }
                 }
             }


### PR DESCRIPTION
In the check orientation step, instead of updating FN when Estimated graph is `--`, we decide to do nothing rather than undapting. This is because `--` means unknown. 