### PR TITLE
Refactor AdTree to cache table dimension sizes.

### DIFF
--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/utils/AdTree.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/utils/AdTree.java
@@ -207,8 +207,6 @@ public class AdTree {
      * first of the first variable, the second coordinate is between 0 and the dimension of the second variable, and so
      * on. The coordinates are 0-based. It is also assumed that the number of coordinates is equal to the number of
      * variables in the table.
-     * <p>
-     * There cannot be more coordinates than there are variables in the table.
      *
      * @param coords the coordinates of the cell.
      * @return the index of the cell in the table.


### PR DESCRIPTION
This commit introduces a new `dims` array in the `AdTree` class to store the number of categories for each variable in the table. This cache aims to improve performance by eliminating repetitive calculations for the number of categories. All code segments relying on `tableVariables.get(i).getNumCategories()` have been updated to use the new `dims` array.