### PR TITLE
Re-enable bounds check for coordinates in AdTree.

### DIFF
--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/utils/AdTree.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/utils/AdTree.java
@@ -403,9 +403,9 @@ public class AdTree {
         for (int i = 0; i < coords.length; i++) {
             int mappedIndex = inverse ? inverseMap.get(i) : i;
 
-//            if (coords[mappedIndex] < 0 || coords[mappedIndex] >= dims[i]) {
-//                throw new IllegalArgumentException("Coordinate " + i + " is out of bounds.");
-//            }
+            if (coords[mappedIndex] < 0 || coords[mappedIndex] >= dims[i]) {
+                throw new IllegalArgumentException("Coordinate " + i + " is out of bounds.");
+            }
 
             cellIndex *= dims[i];
             cellIndex += coords[mappedIndex];


### PR DESCRIPTION
Uncommented the bounds check to ensure coordinates are within valid limits. This prevents potential errors caused by invalid coordinates and strengthens input validation.