### PR TITLE
Markov Checker new case: Gaussian DAG for local graph on Direct Neighbours of target node

### DIFF
--- a/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestCheckNodewiseMarkov.java
+++ b/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestCheckNodewiseMarkov.java
@@ -29,7 +29,8 @@ public class TestCheckNodewiseMarkov {
         File file = new File(filePath);
         if (file.exists()) {
             System.out.println("Loading true graph file: " + filePath);
-            testGaussianDAGPrecisionRecallForLocalOnMarkovBlanket(file, 0.5, 1.0, 0.8);
+            // testGaussianDAGPrecisionRecallForLocalOnMarkovBlanket(file, 0.5, 1.0, 0.8);
+            testGaussianDAGPrecisionRecallForLocalOnDirectNeighbours(file, 0.5, 1.0, 0.8);
         } else {
             System.out.println("File does not exist at the specified path.");
         }
@@ -147,6 +148,77 @@ public class TestCheckNodewiseMarkov {
     public static void testGaussianDAGPrecisionRecallForLocalOnMarkovBlanketUsingLGConfusionMatrix(DataSet data, Graph trueGraph, Graph estimatedCpdag, double threshold, double shuffleThreshold, double lowRecallBound) {
         IndependenceTest fisherZTest = new IndTestFisherZ(data, 0.05);
         MarkovCheck markovCheck = new MarkovCheck(estimatedCpdag, fisherZTest, ConditioningSetType.MARKOV_BLANKET);
+        // Using Local Graph (LG) confusion matrix
+        // ADTest pass/fail threshold default to be 0.05. shuffleThreshold default to be 0.5
+        List<List<Node>> accepts_rejects = markovCheck.getAndersonDarlingTestAcceptsRejectsNodesForAllNodesPlotData2(fisherZTest, estimatedCpdag, trueGraph, threshold, shuffleThreshold, lowRecallBound);
+        List<Node> accepts = accepts_rejects.get(0);
+        List<Node> rejects = accepts_rejects.get(1);
+        System.out.println("Accepts size: " + accepts.size());
+        System.out.println("Rejects size: " + rejects.size());
+    }
+
+    public static void testGaussianDAGPrecisionRecallForLocalOnDirectNeighbours(File txtFile, double threshold, double shuffleThreshold, double lowRecallBound) {
+        Graph trueGraph = GraphSaveLoadUtils.loadGraphTxt(txtFile);
+        System.out.println("Test True Graph: " + trueGraph);
+        System.out.println("Test True Graph size: " + trueGraph.getNodes().size());
+
+        SemPm pm = new SemPm(trueGraph);
+        // Parameters without additional setting default tobe Gaussian
+        SemIm im = new SemIm(pm, new Parameters());
+        // Simulate permuted dataset and save a copy of it.
+        DataSet data = im.simulateData(10000, false);
+        data = DataTransforms.shuffleColumns(data); // Permute the data columns, this matters to some algorithms, e.g. PC.
+        File file = new File(".", "testPermutedData.txt");
+        try {
+            Writer out = new FileWriter(file);
+            DataWriter.writeRectangularData(data, out, '\t');
+            out.close();
+        } catch (IOException e) {
+            TetradLogger.getInstance().log("IO Exception: " + e.getMessage());
+        }
+        SemBicScore score = new SemBicScore(data, false);
+        score.setPenaltyDiscount(2);
+        Graph estimatedCpdag = null;
+        try {
+            estimatedCpdag = new PermutationSearch(new Boss(score)).search();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+//        TODO VBC: Next check different search algo to generate estimated graph. e.g. PC
+        System.out.println("Test Estimated CPDAG Graph: " + estimatedCpdag);
+        System.out.println("~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
+        testGaussianDAGPrecisionRecallForLocalOnMarkovBlanketUsingAdjAHConfusionMatrix(data, trueGraph, estimatedCpdag, threshold, shuffleThreshold, lowRecallBound);
+        testGaussianDAGPrecisionRecallForLocalOnMarkovBlanketUsingLGConfusionMatrix(data, trueGraph, estimatedCpdag, threshold, shuffleThreshold, lowRecallBound);
+        System.out.println("~~~~~~~~~~~~~Full Graph~~~~~~~~~~~~~~~");
+        estimatedCpdag = GraphUtils.replaceNodes(estimatedCpdag, trueGraph.getNodes());
+        double whole_ap = new AdjacencyPrecision().getValue(trueGraph, estimatedCpdag, null, new Parameters());
+        double whole_ar = new AdjacencyRecall().getValue(trueGraph, estimatedCpdag, null, new Parameters());
+        double whole_ahp = new ArrowheadPrecision().getValue(trueGraph, estimatedCpdag, null, new Parameters());
+        double whole_ahr = new ArrowheadRecall().getValue(trueGraph, estimatedCpdag, null, new Parameters());
+        double whole_lgp = new LocalGraphPrecision().getValue(trueGraph, estimatedCpdag, null, new Parameters());
+        double whole_lgr = new LocalGraphRecall().getValue(trueGraph, estimatedCpdag, null, new Parameters());
+        System.out.println("whole_ap: " + whole_ap);
+        System.out.println("whole_ar: " + whole_ar );
+        System.out.println("whole_ahp: " + whole_ahp);
+        System.out.println("whole_ahr: " + whole_ahr);
+        System.out.println("whole_lgp: " + whole_lgp);
+        System.out.println("whole_lgr: " + whole_lgr);
+    }
+
+    public static void testGaussianDAGPrecisionRecallForLocalOnDirectNeighboursUsingAdjAHConfusionMatrix(DataSet data, Graph trueGraph, Graph estimatedCpdag, double threshold, double shuffleThreshold, double lowRecallBound) {
+        IndependenceTest fisherZTest = new IndTestFisherZ(data, 0.05);
+        MarkovCheck markovCheck = new MarkovCheck(estimatedCpdag, fisherZTest, ConditioningSetType.PARENTS_AND_NEIGHBORS);
+        // Using Adj, AH confusion matrix
+        List<List<Node>> accepts_rejects = markovCheck.getAndersonDarlingTestAcceptsRejectsNodesForAllNodesPlotData(fisherZTest, estimatedCpdag, trueGraph, threshold, shuffleThreshold, lowRecallBound);
+        List<Node> accepts = accepts_rejects.get(0);
+        List<Node> rejects = accepts_rejects.get(1);
+        System.out.println("Accepts size: " + accepts.size());
+        System.out.println("Rejects size: " + rejects.size());
+    }
+
+    public static void testGaussianDAGPrecisionRecallForLocalOnDirectNeighboursUsingLGConfusionMatrix(DataSet data, Graph trueGraph, Graph estimatedCpdag, double threshold, double shuffleThreshold, double lowRecallBound) {
+        IndependenceTest fisherZTest = new IndTestFisherZ(data, 0.05);
+        MarkovCheck markovCheck = new MarkovCheck(estimatedCpdag, fisherZTest, ConditioningSetType.PARENTS_AND_NEIGHBORS);
         // Using Local Graph (LG) confusion matrix
         // ADTest pass/fail threshold default to be 0.05. shuffleThreshold default to be 0.5
         List<List<Node>> accepts_rejects = markovCheck.getAndersonDarlingTestAcceptsRejectsNodesForAllNodesPlotData2(fisherZTest, estimatedCpdag, trueGraph, threshold, shuffleThreshold, lowRecallBound);


### PR DESCRIPTION
tested locally. 
this test check the case for Gaussian DAG with `ConditioningSetType.PARENTS_AND_NEIGHBORS`

Runing main method with the call will generate auto created files: 
```
 accepts_AHP_ADTestP_data.csv
        accepts_AHR_ADTestP_data.csv
        accepts_AdjP_ADTestP_data.csv
        accepts_AdjR_ADTestP_data.csv
        accepts_LGP_ADTestP_data.csv
        accepts_LGR_ADTestP_data.csv
        lowAHRecallNodes.csv
        lowAdjRecallNodes.csv
        lowLGRecallNodes.csv
        rejects_AHP_ADTestP_data.csv
        rejects_AHR_ADTestP_data.csv
        rejects_AdjP_ADTestP_data.csv
        rejects_AdjR_ADTestP_data.csv
        rejects_LGP_ADTestP_data.csv
        rejects_LGR_ADTestP_data.csv
        testPermutedData.txt
``` 