### PR TITLE
Connect OrderedLocalMarkovProperty in Markov Check

### DIFF
--- a/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/MarkovCheckEditor.java
+++ b/tetrad-gui/src/main/java/edu/cmu/tetradapp/editor/MarkovCheckEditor.java
@@ -251,9 +251,6 @@ public class MarkovCheckEditor extends JPanel {
                 case "Ordered Local Markov":
                     model.getMarkovCheck().setSetType(ConditioningSetType.ORDERED_LOCAL_MARKOV);
                     break;
-                case "Ordered Local Markov using MBs":
-                    model.getMarkovCheck().setSetType(ConditioningSetType.ORDERED_LOCAL_MARKOV_MB);
-                    break;
                 case "MarkovBlanket(X)":
                     model.getMarkovCheck().setSetType(ConditioningSetType.MARKOV_BLANKET);
                     break;

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/ConditioningSetType.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/ConditioningSetType.java
@@ -58,10 +58,11 @@ public enum ConditioningSetType {
     ORDERED_LOCAL_MARKOV,
 
     /**
-     * Testing independence facts implied by the graph, conditioning on the predecessors of each variable in the graph
-     * in the Markov blanket for a node, in a causal order of the graph. Some independence facts obtained in this way
-     * may be for implied dependencies.
+     * Generates a set of independence facts that implies Global Markov for MAG.
+     * Taking a MAG in the given PAG in the calling method.
+     *
+     * @see OrderedLocalMarkovProperty
      */
-    ORDERED_LOCAL_MARKOV_MB
+    ORDERED_LOCAL_MARKOV_MAG
 
 }


### PR DESCRIPTION
Replaced `ConditioningSetType ORDERED_LOCAL_MARKOV_MB` by `ORDERED_LOCAL_MARKOV_MAG`
Then in Markov Check, get all `allIndependenceFacts` using `OrderedLocalMarkovProperty` in case of `ORDERED_LOCAL_MARKOV_MAG` to generate results. 
