### PR TITLE
Update SemBicScore.java

### DIFF
--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/score/SemBicScore.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/score/SemBicScore.java
@@ -689,8 +689,11 @@ public class SemBicScore implements Score {
 
     private void setCovariances(ICovarianceMatrix covariances) {
         this.covariances = covariances;
-        this.matrix = this.covariances.getMatrix();
-
+        
+        if (this.dataModel == null) {
+            this.matrix = this.covariances.getMatrix();
+        }
+        
         this.dataModel = covariances;
 
     }


### PR DESCRIPTION
When passing a Cov Mat on the Fly to the SEM BIC score, it will compute the full matrix which seems undesirable.

This should be a fix to that situation.

(as far as I can tell)
The only time this.matrix is accessed is when this.dataModel is null but this.dataModel is never null when a Cov Mat on the Fly is passed. Accordingly my fix is to only calculate this.matrix when this.dataModel is null.