### PR TITLE
Check Nodewise Markov add record for true graph's PAG

### DIFF
--- a/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestCheckNodewiseMarkov.java
+++ b/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestCheckNodewiseMarkov.java
@@ -247,7 +247,7 @@ public class TestCheckNodewiseMarkov {
         }
 
         // Simulate different FCI methods
-        List<String> methodNames = Arrays.asList("BossFCI", "GaspFCI", "FCI", "FCIMax", "RFCI");
+        List<String> methodNames = Arrays.asList("BossFCI", "GraspFCI", "FCI", "FCIMax", "RFCI");
         for (String methodName : methodNames) {
             try {
                 Graph estimatedPAG = null;
@@ -264,10 +264,10 @@ public class TestCheckNodewiseMarkov {
                         bossFCI.setGuaranteePag(true);
                         estimatedPAG = bossFCI.search();
                         break;
-                    case "GaspFCI":
-                        GraspFci gaspFCI = new GraspFci(fisherZTest, score);
-                        gaspFCI.setGuaranteePag(true);
-                        estimatedPAG = gaspFCI.search();
+                    case "GraspFCI":
+                        GraspFci graspFCI = new GraspFci(fisherZTest, score);
+                        graspFCI.setGuaranteePag(true);
+                        estimatedPAG = graspFCI.search();
                         break;
                     case "FCI":
                         Fci fci = new Fci(fisherZTest); // seems fci does not need score input?

--- a/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestCheckNodewiseMarkov.java
+++ b/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestCheckNodewiseMarkov.java
@@ -237,6 +237,14 @@ public class TestCheckNodewiseMarkov {
         SemBicScore score = new SemBicScore(data, false);
         score.setPenaltyDiscount(2);
         IndependenceTest fisherZTest = new IndTestFisherZ(data, 0.05);
+        Graph truePAG = GraphTransforms.dagToPag(trueGraph);
+        // record truePAG
+        File truePAGFile = new File(simulationDir, "truePAG.txt");
+        try (Writer out = new FileWriter(truePAGFile)) {
+            out.write(truePAG.toString());
+        } catch (IOException e) {
+            TetradLogger.getInstance().log("IO Exception while saving graph for truePAG " + e.getMessage());
+        }
 
         // Simulate different FCI methods
         List<String> methodNames = Arrays.asList("BossFCI", "GaspFCI", "FCI", "FCIMax", "RFCI");
@@ -297,7 +305,6 @@ public class TestCheckNodewiseMarkov {
                 }
 
                 estimatedPAG = GraphUtils.replaceNodes(estimatedPAG, trueGraph.getNodes());
-                Graph truePAG = GraphTransforms.dagToPag(trueGraph);
 
                 double whole_ap = new AdjacencyPrecision().getValue(truePAG, estimatedPAG, null, new Parameters());
                 double whole_ar = new AdjacencyRecall().getValue(truePAG, estimatedPAG, null, new Parameters());


### PR DESCRIPTION
This PR adds record for PAG version of the true graph. 
Also fixed the issue that for true graph DAG to PAG should be calculated once per simulation. 
![Screenshot 2025-06-01 at 12 43 21 PM](https://github.com/user-attachments/assets/e6d1dac8-b0a0-40e4-a0b5-743ce2f184c9)
