### PR TITLE
Fix R4 and enhance clarity in discriminating path logic

### DIFF
--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/graph/GraphUtils.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/graph/GraphUtils.java
@@ -1175,7 +1175,8 @@ public final class GraphUtils {
 
             graph.addEdge(xyEdge);
 
-            if (graph.paths().defVisible(edge)) {
+            Paths paths = graph.paths();
+            if (paths.defVisiblePag(edge.getNode1(), edge.getNode2())) {
                 edge.addProperty(Property.nl); // solid.
             } else {
                 edge.addProperty(Property.pl); // dashed
@@ -1966,9 +1967,15 @@ public final class GraphUtils {
         if (G2.paths().isLegalMpdag() && G.isAdjacentTo(x, y) && !Edges.isDirectedEdge(G.getEdge(x, y))) {
             System.out.println("The edge from x to y must be visible: " + G.getEdge(x, y));
             return new HashSet<>();
-        } else if (G2.paths().isLegalPag() && G.isAdjacentTo(x, y) && !G.paths().defVisible(G.getEdge(x, y))) {
-            System.out.println("The edge from x to y must be visible:" + G.getEdge(x, y));
-            return new HashSet<>();
+        } else {
+            if (G2.paths().isLegalPag() && G.isAdjacentTo(x, y)) {
+                Paths paths = G.paths();
+                Edge edge = G.getEdge(x, y);
+                if (!paths.defVisiblePag(edge.getNode1(), edge.getNode2())) {
+                    System.out.println("The edge from x to y must be visible:" + G.getEdge(x, y));
+                    return new HashSet<>();
+                }
+            }
         }
 
         // Get the Markov blanket for x in G2.
@@ -2010,9 +2017,15 @@ public final class GraphUtils {
         if (G2.paths().isLegalMpdag() && G.isAdjacentTo(x, y) && !Edges.isDirectedEdge(G.getEdge(x, y))) {
             System.out.println("The edge from x to y must be visible: " + G.getEdge(x, y));
             return new HashSet<>();
-        } else if (G2.paths().isLegalPag() && G.isAdjacentTo(x, y) && !G.paths().defVisible(G.getEdge(x, y))) {
-            System.out.println("The edge from x to y must be visible:" + G.getEdge(x, y));
-            return new HashSet<>();
+        } else {
+            if (G2.paths().isLegalPag() && G.isAdjacentTo(x, y)) {
+                Paths paths = G.paths();
+                Edge edge = G.getEdge(x, y);
+                if (!paths.defVisiblePag(edge.getNode1(), edge.getNode2())) {
+                    System.out.println("The edge from x to y must be visible:" + G.getEdge(x, y));
+                    return new HashSet<>();
+                }
+            }
         }
 
         Set<Node> anteriority = G.paths().anteriority(x, y);
@@ -2092,8 +2105,11 @@ public final class GraphUtils {
             throw new IllegalArgumentException("Edge from x to y must be directed.");
         } else if (edge.pointsTowards(x)) {
             throw new IllegalArgumentException("Edge from x to y must point towards y.");
-        } else if (!G.paths().defVisible(edge)) {
-            throw new IllegalArgumentException("Edge from x to y must be visible.");
+        } else {
+            Paths paths = G.paths();
+            if (!paths.defVisiblePag(edge.getNode1(), edge.getNode2())) {
+                throw new IllegalArgumentException("Edge from x to y must be visible.");
+            }
         }
 
         Graph G2 = new EdgeListGraph(G);

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/utils/DiscriminatingPath.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/utils/DiscriminatingPath.java
@@ -132,7 +132,7 @@ public class DiscriminatingPath {
         }
 
         // Then we need to make sure E and B are on the path, E first, B last:
-        LinkedList<Node> p = new LinkedList<>(colliderPath);
+        LinkedList<Node> p = new LinkedList<>(colliderPath.reversed());
         p.addFirst(x);
         p.addLast(v);
 

--- a/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestFci.java
+++ b/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestFci.java
@@ -33,7 +33,9 @@ import edu.cmu.tetrad.search.score.SemBicScore;
 import edu.cmu.tetrad.search.test.IndTestFisherZ;
 import edu.cmu.tetrad.search.test.MsepTest;
 import edu.cmu.tetrad.search.utils.DagToPag;
+import edu.cmu.tetrad.search.utils.FciOrient;
 import edu.cmu.tetrad.search.utils.GraphSearchUtils;
+import edu.cmu.tetrad.search.utils.R0R4StrategyTestBased;
 import edu.cmu.tetrad.sem.SemIm;
 import edu.cmu.tetrad.sem.SemPm;
 import edu.cmu.tetrad.util.ChoiceGenerator;
@@ -167,7 +169,7 @@ public class TestFci {
     @Test
     public void testSearch4() {
         checkSearch("Latent(G),Latent(R),H-->F,F<--G,G-->A,A<--R,R-->C,B-->C,B-->D,C-->D,F-->D,A-->D",
-                "A<->C,A-->D,Bo->C,Bo->D,Co->D,F<->A,F-->D,Ho->F", new Knowledge());
+                "A<->C,A-->D,Bo->C,B-->D,C-->D,F<->A,F-->D,Ho->F", new Knowledge());
     }
 
     /**
@@ -208,7 +210,7 @@ public class TestFci {
 
         checkSearch("Latent(E),Latent(G),E-->D,E-->H,G-->H,G-->L,D-->L,D-->M," +
                     "H-->M,L-->M,S-->D,I-->S,P-->S",
-                "D<->H,D-->L,D-->M,H-->M,Io->S,L<->H,Lo->M,Po->S,S-->D", new Knowledge());
+                "D<->H,D-->L,D-->M,H-->M,Io->S,L<->H,L-->M,Po->S,S-->D", new Knowledge());
     }
 
     /**
@@ -541,7 +543,7 @@ public class TestFci {
                                   "4. hd --> mb\n" +
                                   "5. i o-> s\n" +
                                   "6. lc <-> hd\n" +
-                                  "7. lc o-> mb\n" +
+                                  "7. lc --> mb\n" +
                                   "8. ps o-> s\n" +
                                   "9. s --> cd";
 
@@ -703,6 +705,46 @@ public class TestFci {
             e.printStackTrace();
         }
     }
+
+    /**
+     * Wondering why the lc->Mb edge is not being oriented by r4 here in puzzle #2...
+     */
+    @Test
+    public void testSearch22() {
+        boolean verbose = false;
+
+        final String pagString = "Graph Nodes:\n" +
+                               "cd;hd;lc;s;i;ps;mb\n" +
+                               "\n" +
+                               "Graph Edges:\n" +
+                               "1. cd --> mb dd nl\n" +
+                               "2. cd --> lc pd nl\n" +
+                               "3. hd --> mb pd nl\n" +
+                               "4. s --> cd pd nl\n" +
+                               "5. cd <-> hd\n" +
+                               "6. i o-> s\n" +
+                               "7. lc <-> hd\n" +
+                               "8. lc o-> mb\n" +
+                               "9. ps o-> s\n" +
+                               "\n";
+
+        try {
+            Graph pag = GraphSaveLoadUtils.readerToGraphTxt(pagString);
+
+            FciOrient fciOrient = new FciOrient(new R0R4StrategyTestBased(new MsepTest(pag)));
+
+            // Need to rig it so it does r4.
+            fciOrient.finalOrientation(pag);
+            
+            System.out.println(pag);  // Should have lc --> mb.
+            
+            
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
 
     private boolean ancestral(Node n, Node q, Graph pag) {
         if (n == q) return false;


### PR DESCRIPTION
### Description
- Resolved issue in R4 where discriminating paths were incorrectly ordered in the collider path. Nodes had been listed in reverse order, and the list was not reversed.
- Replaced `defVisible` with `defVisiblePag` to clarify its specific application to PAGs, aligning definitions with Zhang’s terminologies.
- Simplified the logic, improved readability, and maintained consistency across edge visibility checks.
- Updated related tests and utility methods for correctness and alignment with the new