### PR TITLE
Fix parameter order in MarkovCheckRecord constructor

### DIFF
--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/MarkovCheck.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/MarkovCheck.java
@@ -1279,7 +1279,7 @@ public class MarkovCheck implements EffectiveSampleSizeSettable {
         double fracDepDep = getFractionDependent(false);
         int numTestsInd = getNumTests(true);
         int numTestsDep = getNumTests(false);
-        return new MarkovCheckRecord(adInd, adDep, binIndep, ksInd, ksDep, fishInd, fishDep, binDep, fracDepInd, fracDepDep, numTestsInd, numTestsDep);
+        return new MarkovCheckRecord(adInd, adDep, ksInd, ksDep, fishInd, fishDep, binIndep, binDep, fracDepInd, fracDepDep, numTestsInd, numTestsDep);
     }
 
     /**


### PR DESCRIPTION
### Description

This pull request resolves an issue with the parameter order in the `MarkovCheckRecord` constructor call. The parameters have been reordered to align with the expected order defined in the class. This change ensures proper data consistency and prevents potential errors caused by incorrect parameter mapping.