### PR TITLE
Refactor `refreshGraph` and streamline blocking logic

### DIFF
--- a/tetrad-gui/dependency-reduced-pom.xml
+++ b/tetrad-gui/dependency-reduced-pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>tetrad</artifactId>
     <groupId>io.github.cmu-phil</groupId>
-    <version>7.6.7</version>
+    <version>7.6.8-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tetrad-gui</artifactId>

--- a/tetrad-lib/dependency-reduced-pom.xml
+++ b/tetrad-lib/dependency-reduced-pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>tetrad</artifactId>
     <groupId>io.github.cmu-phil</groupId>
-    <version>7.6.7</version>
+    <version>7.6.8-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>tetrad-lib</artifactId>

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/CompareTwoGraphs.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/CompareTwoGraphs.java
@@ -332,7 +332,8 @@ public class CompareTwoGraphs {
         statistics.add(new AverageDegreeTrue());
         statistics.add(new DensityEst());
         statistics.add(new DensityTrue());
-        statistics.add(new StructuralHammingDistance());
+        statistics.add(new StructuralHammingDistance(false));
+        statistics.add(new StructuralHammingDistance(true));
 
         // Stats for PAGs.
         statistics.add(new NumDirectedEdges());

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/cpdag/Cstar.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/cpdag/Cstar.java
@@ -120,7 +120,13 @@ public class Cstar implements Algorithm, UsesScoreWrapper, TakesIndependenceWrap
 
         if (targetNames.trim().equalsIgnoreCase("all")) {
             for (String name : dataSet.getVariableNames()) {
-                possibleEffects.add(dataSet.getVariable(name));
+                Node variable = dataSet.getVariable(name);
+
+                if (variable == null) {
+                    throw new NullPointerException("Variable " + name + " is not in the dataset.");
+                }
+
+                possibleEffects.add(variable);
             }
         } else {
             String string = parameters.getString(Params.TARGETS);
@@ -133,7 +139,17 @@ public class Cstar implements Algorithm, UsesScoreWrapper, TakesIndependenceWrap
             }
 
             for (String _target : _targets) {
-                possibleEffects.add(dataSet.getVariable(_target));
+                if (_target.trim().isEmpty()) {
+                    continue;
+                }
+
+                Node variable = dataSet.getVariable(_target);
+
+                if (variable == null) {
+                    throw new NullPointerException("Variable " + _target + " is not in the dataset.");
+                }
+
+                possibleEffects.add(variable);
             }
         }
 

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/cpdag/RestrictedBoss.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/algorithm/oracle/cpdag/RestrictedBoss.java
@@ -77,7 +77,13 @@ public class RestrictedBoss extends AbstractBootstrapAlgorithm implements Algori
         List<Node> targets = new ArrayList<>();
 
         for (String _target : _targets) {
-            targets.add(dataSet.getVariable(_target));
+            Node variable = dataSet.getVariable(_target);
+
+            if (variable == null) {
+                continue;
+            }
+
+            targets.add(variable);
         }
 
         for (Node node : targets) {

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/statistic/StructuralHammingDistance.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/statistic/StructuralHammingDistance.java
@@ -19,10 +19,16 @@ public class StructuralHammingDistance implements Statistic {
     @Serial
     private static final long serialVersionUID = 23L;
 
+    private boolean compareToCpdag = false;
+
     /**
      * Constructs the statistic.
      */
     public StructuralHammingDistance() {
+    }
+
+    public StructuralHammingDistance(boolean compareToCpdag) {
+        this.compareToCpdag = compareToCpdag;
     }
 
     /**
@@ -30,7 +36,7 @@ public class StructuralHammingDistance implements Statistic {
      */
     @Override
     public String getAbbreviation() {
-        return "SHD";
+        return "SHD " + (compareToCpdag ? "(CPDAG)" : "(PDAG)");
     }
 
     /**
@@ -38,7 +44,7 @@ public class StructuralHammingDistance implements Statistic {
      */
     @Override
     public String getDescription() {
-        return "Structural Hamming Distance";
+        return "Structural Hamming Distance" +(compareToCpdag ? " compared to CDAG of true PDAG" : " compared to true PDAG");
     }
 
     /**
@@ -46,8 +52,7 @@ public class StructuralHammingDistance implements Statistic {
      */
     @Override
     public double getValue(Graph trueGraph, Graph estGraph, DataModel dataModel, Parameters parameters) {
-        GraphUtils.GraphComparison comparison = GraphSearchUtils.getGraphComparison(trueGraph, estGraph);
-        return comparison.getShd();
+        return GraphSearchUtils.structuralhammingdistance(trueGraph, estGraph, compareToCpdag);
     }
 
     /**

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/graph/Paths.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/graph/Paths.java
@@ -1990,7 +1990,7 @@ public class Paths implements TetradSerializable {
                 if (!(o instanceof EdgeNode _o)) {
                     throw new IllegalArgumentException();
                 }
-                return _o.edge == this.edge && _o.node == this.node;
+                return _o.edge.equals(this.edge) && _o.node.equals(this.node);
             }
         }
 

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/graph/Paths.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/graph/Paths.java
@@ -291,8 +291,10 @@ public class Paths implements TetradSerializable {
 
         try {
             g.paths().makeValidOrder(pi);
-            Graph dag = getDag(pi, g/*GraphTransforms.dagFromCpdag(g)*/, false);
-            Graph cpdag = GraphTransforms.dagToCpdag(dag);
+            Graph cpdag = GraphTransforms.dagToCpdag(GraphTransforms.dagToCpdag(g));
+
+//            Graph dag = getDag(pi, GraphTransforms.dagFromCpdag(g), false);
+//            Graph cpdag = GraphTransforms.dagToCpdag(dag);
             return g.equals(cpdag);
         } catch (Exception e) {
             // There was no valid sink.

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/Fcit.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/Fcit.java
@@ -665,14 +665,7 @@ public final class Fcit implements IGraphSearch {
 
                     Set<Node> b = new HashSet<>(_b);
                     Set<Node> c = GraphUtils.asSet(choice2, common);
-
-                    for (Node n : c) {
-                        if (c.add(n)) {
-                            b.add(n);
-                        } else {
-                            b.remove(n);
-                        }
-                    }
+                    b.removeAll(c);
 
                     if (S.contains(b)) continue;
                     S.add(new HashSet<>(b));

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/Fcit.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/Fcit.java
@@ -371,10 +371,14 @@ public final class Fcit implements IGraphSearch {
                     if (verbose) {
                         TetradLogger.getInstance().log("Tried removing edge " + edge + " for adjacency reasons.");
                     }
+
+                    Graph _pag = new EdgeListGraph(this.pag);
+
                     this.pag.removeEdge(x, y);
                     sepsets.set(x, y, cond);
-                    refreshGraph(x + " _||_ " + y + " | " + cond);
-                    continue EDGE;
+                    if (refreshGraph(x + " _||_ " + y + " | " + cond)) {
+                        continue EDGE;
+                    }
                 }
             }
 
@@ -386,10 +390,14 @@ public final class Fcit implements IGraphSearch {
 
                 if (test.checkIndependence(x, y, cond).isIndependent()) {
                     TetradLogger.getInstance().log("Tried removing edge " + edge + " for adjacency reasons.");
+
+                    Graph _pag = new EdgeListGraph(this.pag);
+
                     this.pag.removeEdge(x, y);
                     sepsets.set(x, y, cond);
-                    refreshGraph(x + " _||_ " + y + " | " + cond);
-                    continue EDGE;
+                    if (refreshGraph(x + " _||_ " + y + " | " + cond)) {
+                        continue EDGE;
+                    }
                 }
             }
         }
@@ -491,7 +499,9 @@ public final class Fcit implements IGraphSearch {
      *
      * @param message A descriptive message indicating the context or purpose of the graph refresh operation.
      */
-    private void refreshGraph(String message) {
+    private boolean refreshGraph(String message) {
+        Graph _pag = new EdgeListGraph(this.pag);
+
         GraphUtils.reorientWithCircles(this.pag, superVerbose);
         GraphUtils.recallInitialColliders(this.pag, initialColliders, knowledge);
         adjustForExtraSepsets();
@@ -500,18 +510,27 @@ public final class Fcit implements IGraphSearch {
 
         // Don't need to check legal PAG here; can limit the check to these two conditions, as removing an edge
         // cannot cause new cycles or almost-cycles to be formed.
-        noteRejects(message);
+        if (!noteRejects(message)) {
+            this.pag = new EdgeListGraph(_pag);
+            return false;
+        } else {
+            return true;
+        }
     }
 
-    private void noteRejects(String message) {
+    private boolean noteRejects(String message) {
         if (!this.pag.paths().isLegalPag()) {
             if (verbose) {
                 TetradLogger.getInstance().log("Rejected: " + message);
             }
+
+            return false;
         } else {
             if (verbose) {
                 TetradLogger.getInstance().log("ACCEPTED: " + message);
             }
+
+            return true;
         }
     }
 
@@ -679,6 +698,8 @@ public final class Fcit implements IGraphSearch {
                             if (verbose) {
                                 TetradLogger.getInstance().log("Tried removing " + edge + " for recursive reasons.");
                             }
+
+                            Graph _pag = new EdgeListGraph(this.pag);
 
                             this.pag.removeEdge(x, y);
                             sepsets.set(x, y, b);

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/Fcit.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/Fcit.java
@@ -319,10 +319,17 @@ public final class Fcit implements IGraphSearch {
         state.storeState();
 
         removeEdgesRecursively();
+        refreshGraph("after recursion");
 
         if (checkAdjacencySepsets) {
             removeEdgesSubsetsOfAdjacents();
         }
+
+        GraphUtils.reorientWithCircles(state.getPag(), superVerbose);
+        GraphUtils.recallInitialColliders(state.getPag(), initialColliders, knowledge);
+        adjustForExtraSepsets();
+        fciOrient.fciOrientbk(knowledge, state.getPag(), state.getPag().getNodes());
+        fciOrient.finalOrientation(state.getPag());
 
         if (superVerbose) {
             TetradLogger.getInstance().log("Doing implied orientation, grabbing unshielded colliders from FciOrient.");
@@ -363,10 +370,12 @@ public final class Fcit implements IGraphSearch {
                     sepsets.set(x, y, cond);
 
                     if (refreshGraph(x + " _||_ " + y + " | " + cond)) {
-                        continue EDGE; // Because we removed the edge and it's a legal PAG
+//                        continue EDGE; // Because we removed the edge and it's a legal PAG
                     } else {
-                        continue EDGE; // Because we found that removing the edge didn't move us to a legal PAG.
+//                        continue EDGE; // Because we found that removing the edge didn't move us to a legal PAG.
                     }
+
+                    continue EDGE;
                 }
             }
 
@@ -382,10 +391,12 @@ public final class Fcit implements IGraphSearch {
                     sepsets.set(x, y, cond);
 
                     if (refreshGraph(x + " _||_ " + y + " | " + cond)) {
-                        continue EDGE; // Because we removed the edge and it's a legal PAG
+//                        continue EDGE; // Because we removed the edge and it's a legal PAG
                     } else {
-                        continue EDGE; // Because we found that removing the edge didn't move us to a legal PAG.
+//                        continue EDGE; // Because we found that removing the edge didn't move us to a legal PAG.
                     }
+
+                    continue EDGE;
                 }
             }
         }
@@ -513,15 +524,18 @@ public final class Fcit implements IGraphSearch {
             if (verbose) {
                 TetradLogger.getInstance().log("Rejected: " + message);
             }
-            state.restoreState();
+//            state.restoreState();
             return false;
         } else {
             if (verbose) {
                 TetradLogger.getInstance().log("ACCEPTED: " + message);
             }
-            state.storeState();
-            return true;
+//            state.storeState();
+//            return true;
         }
+
+//        state.restoreState();
+        return true;
     }
 
     /**
@@ -655,11 +669,11 @@ public final class Fcit implements IGraphSearch {
                     TetradLogger.getInstance().log("Not followed set = " + notFollowed + " b set = " + _b);
                 }
 
-//                // b will be null if the search did not conclude with a set known to either m-separate
-//                // or not m-separate x and y.
-//                if (b == null) {
-//                    continue;
-//                }
+                // b will be null if the search did not conclude with a set known to either m-separate
+                // or not m-separate x and y.
+                if (_b == null) {
+                    continue;
+                }
 
                 List<Node> common = state.getPag().getAdjacentNodes(x);
                 common.retainAll(state.getPag().getAdjacentNodes(y));
@@ -675,10 +689,18 @@ public final class Fcit implements IGraphSearch {
                     Set<Node> b = new HashSet<>(_b);
 
                     Set<Node> c = GraphUtils.asSet(choice2, common);
-                    b.removeAll(c);
+//                    b.removeAll(c);
 
-                    if (S.contains(b)) continue;
-                    S.add(new HashSet<>(b));
+                    for (Node n : c) {
+                        if (c.add(n))                                                                                                                                {
+                            b.add(n);
+                        } else {
+                            b.remove(n);
+                        }
+                    }
+
+//                    if (S.contains(b)) continue;
+//                    S.add(new HashSet<>(b));
 
                     if (b.size() > (depth == -1 ? test.getVariables().size() : depth)) {
                         continue;
@@ -694,10 +716,12 @@ public final class Fcit implements IGraphSearch {
                             sepsets.set(x, y, b);
 
                             if (refreshGraph(x + " _||_ " + y + " | " + b + " (new sepset)")) {
-                                continue EDGE; // Because we removed the edge and it's a legal PAG.
+//                                continue EDGE; // Because we removed the edge and it's a legal PAG.
                             } else {
-                                continue EDGE; // Because we found that removing the edge didn't move us to a legal PAG.
+//                                continue EDGE; // Because we found that removing the edge didn't move us to a legal PAG.
                             }
+
+                            continue EDGE;
                         }
 
                     } catch (InterruptedException e) {

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/Fcit.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/Fcit.java
@@ -376,7 +376,7 @@ public final class Fcit implements IGraphSearch {
 
                     this.pag.removeEdge(x, y);
                     sepsets.set(x, y, cond);
-                    if (refreshGraph(x + " _||_ " + y + " | " + cond)) {
+                    if (refreshGraph(x + " _||_ " + y + " | " + cond, _pag)) {
                         continue EDGE;
                     }
                 }
@@ -395,7 +395,7 @@ public final class Fcit implements IGraphSearch {
 
                     this.pag.removeEdge(x, y);
                     sepsets.set(x, y, cond);
-                    if (refreshGraph(x + " _||_ " + y + " | " + cond)) {
+                    if (refreshGraph(x + " _||_ " + y + " | " + cond, _pag)) {
                         continue EDGE;
                     }
                 }
@@ -498,10 +498,10 @@ public final class Fcit implements IGraphSearch {
      * applying final orientations. This method ensures the PAG remains valid after performing necessary modifications.
      *
      * @param message A descriptive message indicating the context or purpose of the graph refresh operation.
+     * @param _pag    The previous PAG, before the most recent edge removal. If the new PAG is not legal, the graph
+     *                state will be reverted to this PAG.
      */
-    private boolean refreshGraph(String message) {
-        Graph _pag = new EdgeListGraph(this.pag);
-
+    private boolean refreshGraph(String message, Graph _pag) {
         GraphUtils.reorientWithCircles(this.pag, superVerbose);
         GraphUtils.recallInitialColliders(this.pag, initialColliders, knowledge);
         adjustForExtraSepsets();
@@ -510,27 +510,35 @@ public final class Fcit implements IGraphSearch {
 
         // Don't need to check legal PAG here; can limit the check to these two conditions, as removing an edge
         // cannot cause new cycles or almost-cycles to be formed.
-        if (!noteRejects(message)) {
+        if (newLegalPag(message)) {
+            return true;
+        } else {
             this.pag = new EdgeListGraph(_pag);
             return false;
-        } else {
-            return true;
         }
     }
 
-    private boolean noteRejects(String message) {
-        if (!this.pag.paths().isLegalPag()) {
-            if (verbose) {
-                TetradLogger.getInstance().log("Rejected: " + message);
-            }
-
-            return false;
-        } else {
+    /**
+     * Checks if the current Partial Ancestral Graph (PAG) is legal and logs the result. A PAG is considered legal based
+     * on specific structural criteria defined by the algorithm.
+     *
+     * @param message A string message describing the context or purpose of the legality check. This is logged to
+     *                provide additional context when verbose mode is enabled.
+     * @return True if the PAG is legal, false otherwise. The result is logged when verbose mode is enabled.
+     */
+    private boolean newLegalPag(String message) {
+        if (this.pag.paths().isLegalPag()) {
             if (verbose) {
                 TetradLogger.getInstance().log("ACCEPTED: " + message);
             }
 
             return true;
+        } else {
+            if (verbose) {
+                TetradLogger.getInstance().log("Rejected: " + message);
+            }
+
+            return false;
         }
     }
 
@@ -703,7 +711,7 @@ public final class Fcit implements IGraphSearch {
 
                             this.pag.removeEdge(x, y);
                             sepsets.set(x, y, b);
-                            refreshGraph(x + " _||_ " + y + " | " + b + " (new sepset)");
+                            refreshGraph(x + " _||_ " + y + " | " + b + " (new sepset)", _pag);
                             continue EDGE;
                         }
 

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/Ida.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/Ida.java
@@ -75,8 +75,8 @@ public class Ida {
         }
 
         // Check tha the graph is either a DAG or a CPDAG.
-        if (!(graph.paths().isLegalDag() || graph.paths().isLegalCpdag())) {
-            throw new IllegalArgumentException("Expecting a DAG or a CPDAG.");
+        if (!(graph.paths().isLegalMpdag())) {
+            throw new IllegalArgumentException("Expecting an MPDAG.");
         }
 
         // Check that the dataset is continuous.

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/RecursiveBlocking.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/RecursiveBlocking.java
@@ -54,20 +54,20 @@ public class RecursiveBlocking {
 
         Set<Node> path = new HashSet<>();
         path.add(x);
-        boolean allBlocked = true;
+//        boolean allBlocked = true;
 
         for (Node b : graph.getAdjacentNodes(x)) {
             if (Thread.currentThread().isInterrupted()) {
                 return null;
             }
 
-            if (b == y) continue;
+//            if (b == y) continue;
 
-            Blockable blockable = findPathToTarget(graph, x, b, y, path, z, maxPathLength, notFollowed, ancestorMap);
+            findPathToTarget(graph, x, b, y, path, z, maxPathLength, notFollowed, ancestorMap);
 
-            if (blockable != Blockable.BLOCKED) {
-                allBlocked = false;
-            }
+//            if (blockable == Blockable.UNBLOCKABLE) {
+//                allBlocked = false;
+//            }
         }
 
         return z;

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/SepsetFinder.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/SepsetFinder.java
@@ -43,12 +43,12 @@ public class SepsetFinder {
         List<List<Integer>> choices = getChoices(adjx, depth);
 
         // Parallelize processing for adjx
-        Set<Node> sepset = choices.parallelStream()
+        Set<Node> sepset = choices.stream()
                 .map(choice -> combination(choice, adjx)) // Generate combinations in parallel
                 .filter(subset -> subset.containsAll(containing)) // Filter combinations that don't contain 'containing'
                 .filter(subset -> {
                     try {
-                        return separates(x, y, subset, test);
+                        return test.checkIndependence(x, y, subset).isIndependent();
                     } catch (InterruptedException e) {
                         throw new RuntimeException(e);
                     }
@@ -68,7 +68,7 @@ public class SepsetFinder {
                 .filter(subset -> subset.containsAll(containing)) // Filter combinations that don't contain 'containing'
                 .filter(subset -> {
                     try {
-                        return separates(x, y, subset, test);
+                        return test.checkIndependence(x, y, subset).isIndependent();
                     } catch (InterruptedException e) {
                         throw new RuntimeException(e);
                     }
@@ -129,7 +129,7 @@ public class SepsetFinder {
                 .filter(subset -> subset.containsAll(containing)) // Filter combinations that don't contain 'containing'
                 .filter(subset -> {
                     try {
-                        return separates(x, y, subset, test);
+                        return test.checkIndependence(x, y, subset).isIndependent();
                     } catch (InterruptedException e) {
                         throw new RuntimeException(e);
                     }
@@ -193,7 +193,7 @@ public class SepsetFinder {
             if (containing != null && !subset.containsAll(containing)) continue;
 
             // Check if the subset is a separating set
-            if (separates(x, y, subset, test)) {
+            if (test.checkIndependence(x, y, subset).isIndependent()) {
                 double pValue = getPValue(x, y, subset, test);
 
                 // Track the subset with the highest p-value
@@ -252,7 +252,7 @@ public class SepsetFinder {
             Set<Node> subset = combination(choice, adj);
 
             // Check if the subset is a separating set
-            if (separates(x, y, subset, test)) {
+            if (test.checkIndependence(x, y, subset).isIndependent()) {
                 double pValue = getPValue(x, y, subset, test);
 
                 // Track the subset with the smallest p-value that is still above the alpha threshold
@@ -307,10 +307,6 @@ public class SepsetFinder {
         }
 
         return combination;
-    }
-
-    private static boolean separates(Node x, Node y, Set<Node> combination, IndependenceTest test) throws InterruptedException {
-        return test.checkIndependence(x, y, combination).isIndependent();
     }
 
     private static double getPValue(Node x, Node y, Set<Node> combination, IndependenceTest test) {

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/utils/GraphSearchUtils.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/utils/GraphSearchUtils.java
@@ -1045,6 +1045,14 @@ public final class GraphSearchUtils {
     public static int structuralHammingDistance(Graph trueGraph, Graph estGraph) {
         int shd = 0;
 
+        if (trueGraph.paths().isLegalCpdag()) {
+            return -99;
+        }
+
+        if (!estGraph.paths().isLegalCpdag()) {
+            return -99;
+        }
+
         try {
             estGraph = GraphUtils.replaceNodes(estGraph, trueGraph.getNodes());
             trueGraph = GraphTransforms.dagToCpdag(trueGraph);

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/utils/GraphSearchUtils.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/utils/GraphSearchUtils.java
@@ -1013,7 +1013,7 @@ public final class GraphSearchUtils {
      * Originally, Tsamardinos, I., Brown, L. E., and Aliferis, C. F. (2006). The max-min hill-climbing Bayesian network
      * structure learning algorithm. Machine learning, 65(1), 31-78.
      * <p>
-     * But using the formulation in Peters, J., & Bühlmann, P. (2015). Structural intervention distance for evaluating
+     * But using the formulation in Peters, J., &amp; Bühlmann, P. (2015). Structural intervention distance for evaluating
      * causal graphs. Neural computation, 27(3), 771-799.
      * <p>
      * Converts each graph (DAG or CPDAG) into its CPDAG before scoring.

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/utils/GraphSearchUtils.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/utils/GraphSearchUtils.java
@@ -1,4 +1,4 @@
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 // For information as to what this class does, see the Javadoc, below.       //
 // Copyright (C) 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005, 2006,       //
 // 2007, 2008, 2009, 2010, 2014, 2015, 2022 by Peter Spirtes, Richard        //
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU General Public License         //
 // along with this program; if not, write to the Free Software               //
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA //
-///////////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////////
 package edu.cmu.tetrad.search.utils;
 
 import edu.cmu.tetrad.algcomparison.CompareTwoGraphs;
@@ -185,8 +185,7 @@ public final class GraphSearchUtils {
                     continue;
                 }
 
-                if (!GraphSearchUtils.isArrowheadAllowed(x, y, knowledge)
-                    || !GraphSearchUtils.isArrowheadAllowed(z, y, knowledge)) {
+                if (!GraphSearchUtils.isArrowheadAllowed(x, y, knowledge) || !GraphSearchUtils.isArrowheadAllowed(z, y, knowledge)) {
                     continue;
                 }
 
@@ -242,8 +241,7 @@ public final class GraphSearchUtils {
      * @param verbose      a boolean
      * @param enforceCpdag a boolean
      */
-    public static void orientCollidersUsingSepsets(SepsetMap set, Knowledge knowledge, Graph graph, boolean verbose,
-                                                   boolean enforceCpdag) {
+    public static void orientCollidersUsingSepsets(SepsetMap set, Knowledge knowledge, Graph graph, boolean verbose, boolean enforceCpdag) {
         TetradLogger.getInstance().log("Starting Collider Orientation:");
         List<Node> nodes = graph.getNodes();
 
@@ -269,12 +267,10 @@ public final class GraphSearchUtils {
                 Set<Node> sepset = set.get(a, c);
 
                 //I think the null check needs to be here --AJ
-                if (sepset != null && !sepset.contains(b)
-                    && GraphSearchUtils.isArrowheadAllowed(a, b, knowledge)) {
+                if (sepset != null && !sepset.contains(b) && GraphSearchUtils.isArrowheadAllowed(a, b, knowledge)) {
                     boolean result = true;
                     if (knowledge != null) {
-                        result = !knowledge.isRequired(((Object) b).toString(), ((Object) c).toString())
-                                 && !knowledge.isForbidden(((Object) c).toString(), ((Object) b).toString());
+                        result = !knowledge.isRequired(((Object) b).toString(), ((Object) c).toString()) && !knowledge.isForbidden(((Object) c).toString(), ((Object) b).toString());
                     }
                     if (result) {
 //                        if (verbose) {
@@ -312,13 +308,11 @@ public final class GraphSearchUtils {
      * @param knowledge a {@link edu.cmu.tetrad.data.Knowledge} object
      * @return a boolean
      */
-    public static boolean isArrowheadAllowed(Object from, Object to,
-                                             Knowledge knowledge) {
+    public static boolean isArrowheadAllowed(Object from, Object to, Knowledge knowledge) {
         if (knowledge == null) {
             return true;
         }
-        return !knowledge.isRequired(to.toString(), from.toString())
-               && !knowledge.isForbidden(from.toString(), to.toString());
+        return !knowledge.isRequired(to.toString(), from.toString()) && !knowledge.isForbidden(from.toString(), to.toString());
     }
 
     /**
@@ -406,8 +400,7 @@ public final class GraphSearchUtils {
     public static LegalPagRet isLegalPag(Graph pag, Set<Node> selection) {
         for (Node n : pag.getNodes()) {
             if (n.getNodeType() != NodeType.MEASURED) {
-                return new LegalPagRet(false,
-                        "Node " + n + " is not measured");
+                return new LegalPagRet(false, "Node " + n + " is not measured");
             }
         }
 
@@ -426,16 +419,12 @@ public final class GraphSearchUtils {
             for (Edge e : pag.getEdges()) {
                 Edge e2 = pag2.getEdge(e.getNode1(), e.getNode2());
                 if (!e.equals(e2)) {
-                    edgeMismatch = "For example, the original PAG has edge " + e +
-                                   " whereas the reconstituted graph has edge " + e2;
+                    edgeMismatch = "For example, the original PAG has edge " + e + " whereas the reconstituted graph has edge " + e2;
                     break;
                 }
             }
 
-            String reason = legalMag.isLegalMag()
-                    ? "The MAG implied by this graph was a legal MAG, but one cannot recover the original graph " +
-                      "by finding the PAG of an implied MAG — this graph may lie between a MAG and a PAG"
-                    : "The MAG implied by this graph was not legal, and one cannot recover the original graph from its implied PAG";
+            String reason = legalMag.isLegalMag() ? "The MAG implied by this graph was a legal MAG, but one cannot recover the original graph " + "by finding the PAG of an implied MAG — this graph may lie between a MAG and a PAG" : "The MAG implied by this graph was not legal, and one cannot recover the original graph from its implied PAG";
 
             if (!edgeMismatch.isEmpty()) {
                 reason += ". " + edgeMismatch;
@@ -482,8 +471,7 @@ public final class GraphSearchUtils {
 
         for (Node n : mag.getNodes()) {
             if (mag.paths().existsDirectedPath(n, n)) {
-                return new LegalMagRet(false,
-                        "Acyclicity violated: There is a directed cyclic path from " + n + " to itself");
+                return new LegalMagRet(false, "Acyclicity violated: There is a directed cyclic path from " + n + " to itself");
             }
         }
 
@@ -494,16 +482,12 @@ public final class GraphSearchUtils {
             if (Edges.isBidirectedEdge(e)) {
                 List<List<Node>> forwardPaths = mag.paths().directedPaths(x, y, 1);
                 if (!forwardPaths.isEmpty()) {
-                    return new LegalMagRet(false,
-                            "Bidirected edge semantics is violated: Directed path exists from " + x + " to " + y +
-                            ". An example path is " + GraphUtils.pathString(mag, forwardPaths.getFirst(), false));
+                    return new LegalMagRet(false, "Bidirected edge semantics is violated: Directed path exists from " + x + " to " + y + ". An example path is " + GraphUtils.pathString(mag, forwardPaths.getFirst(), false));
                 }
 
                 List<List<Node>> backwardPaths = mag.paths().directedPaths(y, x, 1);
                 if (!backwardPaths.isEmpty()) {
-                    return new LegalMagRet(false,
-                            "Bidirected edge semantics is violated: Directed path exists from " + y + " to " + x +
-                            ". An example path is " + GraphUtils.pathString(mag, backwardPaths.getFirst(), false));
+                    return new LegalMagRet(false, "Bidirected edge semantics is violated: Directed path exists from " + y + " to " + x + ". An example path is " + GraphUtils.pathString(mag, backwardPaths.getFirst(), false));
                 }
             }
         }
@@ -517,8 +501,7 @@ public final class GraphSearchUtils {
 
                 if (!mag.isAdjacentTo(x, y)) {
                     if (mag.paths().existsInducingPath(x, y, sel)) {
-                        return new LegalMagRet(false,
-                                "Not maximal: Inducing path exists between non-adjacent " + x + " and " + y);
+                        return new LegalMagRet(false, "Not maximal: Inducing path exists between non-adjacent " + x + " and " + y);
                     }
                 }
             }
@@ -532,16 +515,14 @@ public final class GraphSearchUtils {
                 for (Node z : mag.getAdjacentNodes(x)) {
                     Edge zx = mag.getEdge(z, x);
                     if (mag.isParentOf(z, x) || Edges.isBidirectedEdge(zx)) {
-                        return new LegalMagRet(false,
-                                "Undirected edge constraint violated: " + z + " is a parent or spouse of " + x);
+                        return new LegalMagRet(false, "Undirected edge constraint violated: " + z + " is a parent or spouse of " + x);
                     }
                 }
 
                 for (Node z : mag.getAdjacentNodes(y)) {
                     Edge zy = mag.getEdge(z, y);
                     if (mag.isParentOf(z, y) || Edges.isBidirectedEdge(zy)) {
-                        return new LegalMagRet(false,
-                                "Undirected edge constraint violated: " + z + " is a parent or spouse of " + y);
+                        return new LegalMagRet(false, "Undirected edge constraint violated: " + z + " is a parent or spouse of " + y);
                     }
                 }
             }
@@ -725,8 +706,7 @@ public final class GraphSearchUtils {
      * @param graph     a {@link edu.cmu.tetrad.graph.Graph} object
      * @param knowledge a {@link edu.cmu.tetrad.data.Knowledge} object
      */
-    public static void arrangeByKnowledgeTiers(Graph graph,
-                                               Knowledge knowledge) {
+    public static void arrangeByKnowledgeTiers(Graph graph, Knowledge knowledge) {
         if (knowledge.getNumTiers() == 0) {
             throw new IllegalArgumentException("There are no Tiers to arrange.");
         }
@@ -856,8 +836,7 @@ public final class GraphSearchUtils {
      * <p>
      * The algorithm used is a variant of Algorithm 1 from Geiger, Verma, and Pearl (1990).
      */
-    public static Set<Node> getReachableNodes(List<Node> initialNodes, LegalPairs legalPairs, List<Node> c,
-                                              List<Node> d, Graph graph, int maxPathLength) {
+    public static Set<Node> getReachableNodes(List<Node> initialNodes, LegalPairs legalPairs, List<Node> c, List<Node> d, Graph graph, int maxPathLength) {
         HashSet<Node> reachable = new HashSet<>();
         MultiKeyMap<Node, Boolean> visited = new MultiKeyMap<>();
         List<ReachabilityEdge> nextEdges = new LinkedList<>();
@@ -961,9 +940,7 @@ public final class GraphSearchUtils {
      * @return a {@link edu.cmu.tetrad.search.utils.GraphSearchUtils.CpcTripleType} object
      * @throws java.lang.InterruptedException if any.
      */
-    public static CpcTripleType getCpcTripleType(Node x, Node y, Node z,
-                                                 IndependenceTest test, int depth,
-                                                 Graph graph) throws InterruptedException {
+    public static CpcTripleType getCpcTripleType(Node x, Node y, Node z, IndependenceTest test, int depth, Graph graph) throws InterruptedException {
         int numSepsetsContainingY = 0;
         int numSepsetsNotContainingY = 0;
 
@@ -1033,40 +1010,52 @@ public final class GraphSearchUtils {
     }
 
     /**
-     * Tsamardinos, I., Brown, L. E., and Aliferis, C. F. (2006). The max-min hill-climbing Bayesian network structure
-     * learning algorithm. Machine learning, 65(1), 31-78.
+     * Originally, Tsamardinos, I., Brown, L. E., and Aliferis, C. F. (2006). The max-min hill-climbing Bayesian network
+     * structure learning algorithm. Machine learning, 65(1), 31-78.
+     * <p>
+     * But using the formulation in Peters, J., & Bühlmann, P. (2015). Structural intervention distance for evaluating
+     * causal graphs. Neural computation, 27(3), 771-799.
      * <p>
      * Converts each graph (DAG or CPDAG) into its CPDAG before scoring.
      *
-     * @param trueGraph a {@link edu.cmu.tetrad.graph.Graph} object
-     * @param estGraph  a {@link edu.cmu.tetrad.graph.Graph} object
+     * @param trueGraph    a {@link Graph} object
+     * @param estGraph     a {@link Graph} object
+     * @param useTrueCpdag Use the CPDAG of the true graph.
      * @return a int
      */
-    public static int structuralHammingDistance(Graph trueGraph, Graph estGraph) {
+    public static int structuralhammingdistance(Graph trueGraph, Graph estGraph, boolean useTrueCpdag) {
         int shd = 0;
 
-        if (trueGraph.paths().isLegalCpdag()) {
+        if (useTrueCpdag) {
+            trueGraph = GraphTransforms.dagToCpdag(trueGraph);
+        }
+
+        for (Edge e : trueGraph.getEdges()) {
+            if (!(Edges.isUndirectedEdge(e) || Edges.isDirectedEdge(e))) {
+                TetradLogger.getInstance().log("True graph is not a legal PDAG.");
+                return -99;
+            }
+        }
+
+        for (Edge e : estGraph.getEdges()) {
+            if (!(Edges.isUndirectedEdge(e) || Edges.isDirectedEdge(e))) {
+                TetradLogger.getInstance().log("Est graph is not a legal PDAG.");
+                return -99;
+            }
+        }
+
+        if (trueGraph.paths().existsDirectedCycle()) {
+            TetradLogger.getInstance().log("True graph is not a legal PDAG.");
             return -99;
         }
 
-        if (!estGraph.paths().isLegalCpdag()) {
+        if (estGraph.paths().existsDirectedCycle()) {
+            TetradLogger.getInstance().log("Est graph is not a legal PDAG.");
             return -99;
         }
 
         try {
             estGraph = GraphUtils.replaceNodes(estGraph, trueGraph.getNodes());
-            trueGraph = GraphTransforms.dagToCpdag(trueGraph);
-            estGraph = GraphTransforms.dagToCpdag(estGraph);
-
-            // Will check mixedness later.
-            if (trueGraph.paths().existsDirectedCycle()) {
-                TetradLogger.getInstance().log("SHD failed: True graph couldn't be converted to a CPDAG");
-            }
-
-            if (estGraph.paths().existsDirectedCycle()) {
-                TetradLogger.getInstance().log("SHD failed: Estimated graph couldn't be converted to a CPDAG");
-                return -99;
-            }
 
             List<Node> _allNodes = estGraph.getNodes();
 
@@ -1078,58 +1067,28 @@ public final class GraphSearchUtils {
                     Edge e1 = trueGraph.getEdge(n1, n2);
                     Edge e2 = estGraph.getEdge(n1, n2);
 
-                    if (e1 != null && !(Edges.isDirectedEdge(e1) || Edges.isUndirectedEdge(e1))) {
-                        TetradLogger.getInstance().log("SHD failed: True graph couldn't be converted to a CPDAG");
-                        return -99;
-                    }
-
-                    if (e2 != null && !(Edges.isDirectedEdge(e2) || Edges.isUndirectedEdge(e2))) {
-                        TetradLogger.getInstance().log("SHD failed: Estimated graph couldn't be converted to a CPDAG");
-                        return -99;
-                    }
-
                     int error = GraphSearchUtils.structuralHammingDistanceOneEdge(e1, e2);
                     shd += error;
                 }
             }
         } catch (Exception e) {
-            e.printStackTrace();
             return -99;
         }
 
         return shd;
     }
 
-    // Anne Helby pointed out this number was wrong, so replacing it with a different count
-    // per edge, which is either 0 or 1 always per edge.
     private static int structuralHammingDistanceOneEdge(Edge e1, Edge e2) {
-        // Skeleton difference
-        if (e1 == null && e2 == null) return 0;
-        if (e1 == null || e2 == null) return 1;
-
-        // Both edges present – only orientation can differ now
-        return e1.equals(e2) ? 0 : 1;
+        if (e1 == null && e2 == null) {
+            return 0;
+        } else if (e1 == null & e2 != null) {
+            return 1;
+        } else if (e1 != null && e2 == null) {
+            return 1;
+        } else {
+            return e1.equals(e2) ? 0 : 1;
+        }
     }
-
-
-//    private static int structuralHammingDistanceOneEdge(Edge e1, Edge e2) {
-//        int error = 0;
-//
-//        if (!(e1 == null && e2 == null)) {
-//            if (e1 != null && e2 != null) {
-//                if (!e1.equals(e2)) {
-//                    error++;
-//                }
-//            } else if (Edges.isUndirectedEdge(Objects.requireNonNullElse(e2, e1))) {
-//                error++;
-//            } else {
-//                error++;
-//                error++;
-//            }
-//        }
-//
-//        return error;
-//    }
 
     /**
      * Just counts arrowhead errors--for cyclic edges counts an arrowhead at each node.
@@ -1251,8 +1210,7 @@ public final class GraphSearchUtils {
                 Endpoint e2a = _edge.getProximalEndpoint(node1);
                 Endpoint e2b = _edge.getProximalEndpoint(node2);
 
-                if (!((e1a != Endpoint.CIRCLE && e2a != Endpoint.CIRCLE && e1a != e2a)
-                      || (e1b != Endpoint.CIRCLE && e2b != Endpoint.CIRCLE && e1b != e2b))) {
+                if (!((e1a != Endpoint.CIRCLE && e2a != Endpoint.CIRCLE && e1a != e2a) || (e1b != Endpoint.CIRCLE && e2b != Endpoint.CIRCLE && e1b != e2b))) {
                     continue;
                 }
             }
@@ -1263,15 +1221,14 @@ public final class GraphSearchUtils {
         double arrowptPrec = (double) arrowptCorrect / (arrowptCorrect + arrowptFp);
         double arrowptRec = (double) arrowptCorrect / (arrowptCorrect + arrowptFn);
 
-        int shd = structuralHammingDistance(trueGraph, targetGraph);
+        int shdGraphGraph = structuralhammingdistance(trueGraph, targetGraph, false);
+
 
         targetGraph = GraphUtils.replaceNodes(targetGraph, trueGraph.getNodes());
 
         int[][] counts = GraphUtils.edgeMisclassificationCounts(trueGraph, targetGraph, false);
 
-        return new GraphUtils.GraphComparison(
-                adjFn, adjFp, adjCorrect, arrowptFn, arrowptFp, arrowptCorrect,
-                adjPrec, adjRec, arrowptPrec, arrowptRec, shd, edgesAdded, edgesRemoved, counts);
+        return new GraphUtils.GraphComparison(adjFn, adjFp, adjCorrect, arrowptFn, arrowptFp, arrowptCorrect, adjPrec, adjRec, arrowptPrec, arrowptRec, shdGraphGraph, edgesAdded, edgesRemoved, counts);
     }
 
     /**
@@ -1283,8 +1240,7 @@ public final class GraphSearchUtils {
      * @param targetGraph     a {@link edu.cmu.tetrad.graph.Graph} object
      * @return a {@link java.lang.String} object
      */
-    public static String getEdgewiseComparisonString(String trueGraphName, Graph trueGraph,
-                                                     String targetGraphName, Graph targetGraph) {
+    public static String getEdgewiseComparisonString(String trueGraphName, Graph trueGraph, String targetGraphName, Graph targetGraph) {
         targetGraph = GraphUtils.replaceNodes(targetGraph, trueGraph.getNodes());
         trueGraph = new EdgeListGraph(trueGraph);
         targetGraph = new EdgeListGraph(targetGraph);
@@ -1350,8 +1306,7 @@ public final class GraphSearchUtils {
         if (out != null) {
             out.println();
             out.println("APRE\tAREC\tOPRE\tOREC");
-            out.println(nf.format(adjPrecision * 100) + "%\t" + nf.format(adjRecall * 100)
-                        + "%\t" + nf.format(arrowPrecision * 100) + "%\t" + nf.format(arrowRecall * 100) + "%");
+            out.println(nf.format(adjPrecision * 100) + "%\t" + nf.format(adjRecall * 100) + "%\t" + nf.format(arrowPrecision * 100) + "%\t" + nf.format(arrowRecall * 100) + "%");
             out.println();
         }
 

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/utils/R0R4StrategyTestBased.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/utils/R0R4StrategyTestBased.java
@@ -223,7 +223,7 @@ public class R0R4StrategyTestBased implements R0R4Strategy {
             blocking = RecursiveDiscriminatingPathRule.findDdpSepsetRecursive(test, graph, x, y, new FciOrient(new R0R4StrategyTestBased(test)),
                     maxLength, maxLength, preserveMarkovHelper, depth);
 
-            if (blocking == null || !test.checkIndependence(x, y, blocking).isIndependent()) {
+            if (!test.checkIndependence(x, y, blocking).isIndependent()) {
                 blocking = findAdjSetSepset(graph, x, y, path, v);
 
                 if (blocking != null) {
@@ -326,27 +326,27 @@ public class R0R4StrategyTestBased implements R0R4Strategy {
     }
 
     private @Nullable Set<Node> findAdjSetSepset(Graph graph, Node x, Node y, List<Node> path, Node v) throws InterruptedException {
-        Set<Node> blocking;
-        blocking = SepsetFinder.findSepsetSubsetOfAdjxOrAdjy(graph, x, y, new HashSet<>(path), test, depth);
+//        Set<Node> blocking;
+        return SepsetFinder.findSepsetSubsetOfAdjxOrAdjy(graph, x, y, new HashSet<>(path), test, depth);
 
-        Set<Node> b1 = new HashSet<>(blocking);
-        b1.remove(v);
-
-        boolean b1Indep = test.checkIndependence(x, y, b1).isIndependent();
-
-        Set<Node> b2 = new HashSet<>(b1);
-        b2.add(v);
-
-        boolean b2Indep = test.checkIndependence(x, y, b2).isIndependent();
-
-        if (b1Indep) {
-            blocking = b1;
-        } else if (b2Indep) {
-            blocking = b2;
-        } else {
-            blocking = null;
-        }
-        return blocking;
+//        Set<Node> b1 = new HashSet<>(blocking);
+//        b1.remove(v);
+//
+//        boolean b1Indep = test.checkIndependence(x, y, b1).isIndependent();
+//
+//        Set<Node> b2 = new HashSet<>(b1);
+//        b2.add(v);
+//
+//        boolean b2Indep = test.checkIndependence(x, y, b2).isIndependent();
+//
+//        if (b1Indep) {
+//            blocking = b1;
+//        } else if (b2Indep) {
+//            blocking = b2;
+//        } else {
+//            blocking = null;
+//        }
+//        return blocking;
     }
 
     /**

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/utils/R0R4StrategyTestBased.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/utils/R0R4StrategyTestBased.java
@@ -223,27 +223,27 @@ public class R0R4StrategyTestBased implements R0R4Strategy {
 
             // Else for the recursive option see if you can find a recursive sepset; this fails for Puzzle #2.
             if (blockingType == BlockingType.RECURSIVE) {
-            blocking = RecursiveDiscriminatingPathRule.findDdpSepsetRecursive(test, graph, x, y, new FciOrient(new R0R4StrategyTestBased(test)),
-                    maxLength, maxLength, preserveMarkovHelper, depth);
+                blocking = RecursiveDiscriminatingPathRule.findDdpSepsetRecursive(test, graph, x, y, new FciOrient(new R0R4StrategyTestBased(test)),
+                        maxLength, maxLength, preserveMarkovHelper, depth);
 
-            if (blocking == null) { // If it does fail, use FCI style reasoning.
-                blocking = SepsetFinder.findSepsetSubsetOfAdjxOrAdjy(graph, x, y, new HashSet<>(path), test, depth);
+                if (blocking == null) { // If it does fail, use FCI style reasoning.
+                    blocking = SepsetFinder.findSepsetSubsetOfAdjxOrAdjy(graph, x, y, new HashSet<>(path), test, depth);
 
-                if (verbose && blocking != null) {
-                    TetradLogger.getInstance().log("Recursive blocking not found; found FCI-style blocking.");
+                    if (verbose && blocking != null) {
+                        TetradLogger.getInstance().log("Recursive blocking not found; found FCI-style blocking.");
+                    }
                 }
-            }
 
-            sepsetMap.set(x, y, blocking);
-        } else
+                sepsetMap.set(x, y, blocking);
+            } else
 
-            // Else for the greedy option, do FCI-style reasoning.
-            if (blockingType == BlockingType.GREEDY) {
-            blocking = SepsetFinder.findSepsetSubsetOfAdjxOrAdjy(graph, x, y, new HashSet<>(path), test, depth);
-            sepsetMap.set(x, y, blocking);
-        } else {
-            throw new IllegalArgumentException("Unknown blocking type.");
-        }
+                // Else for the greedy option, do FCI-style reasoning.
+                if (blockingType == BlockingType.GREEDY) {
+                    blocking = SepsetFinder.findSepsetSubsetOfAdjxOrAdjy(graph, x, y, new HashSet<>(path), test, depth);
+                    sepsetMap.set(x, y, blocking);
+                } else {
+                    throw new IllegalArgumentException("Unknown blocking type.");
+                }
 
         //  *         V
         // *         **            * is either an arrowhead, a tail, or a circle
@@ -258,14 +258,8 @@ public class R0R4StrategyTestBased implements R0R4Strategy {
             throw new IllegalArgumentException("Blocking set is null in R4.");
         }
 
-        if (blockingType == BlockingType.RECURSIVE) {
-            if (!(blocking.containsAll(path) && blocking.contains(w))) {
-                throw new IllegalArgumentException("Blocking set is not correct; it should contain the path (including W) and V.");
-            }
-        }
-
-        if (blockingType == BlockingType.GREEDY && !blocking.containsAll(path)) {
-            throw new IllegalArgumentException("Blocking set is not correct; it should contain the path.");
+        if (!(blocking.containsAll(path) && blocking.contains(w))) {
+            throw new IllegalArgumentException("Blocking set is not correct; it should contain the path (including W) and V.");
         }
 
         // Now at this point, for the recursive case, we simply need to know whether X _||_ Y | blocking. If so, we

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/utils/R0R4StrategyTestBased.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/utils/R0R4StrategyTestBased.java
@@ -215,13 +215,18 @@ public class R0R4StrategyTestBased implements R0R4Strategy {
 
         Set<Node> blocking;
 
+        // If you already have a sepset, use it.
         if (sepsetMap.get(x, y) != null) {
             blocking = sepsetMap.get(x, y);
-        } else if (blockingType == BlockingType.RECURSIVE) {
+
+        } else
+
+            // Else for the recursive option see if you can find a recursive sepset; this fails for Puzzle #2.
+            if (blockingType == BlockingType.RECURSIVE) {
             blocking = RecursiveDiscriminatingPathRule.findDdpSepsetRecursive(test, graph, x, y, new FciOrient(new R0R4StrategyTestBased(test)),
                     maxLength, maxLength, preserveMarkovHelper, depth);
 
-            if (blocking == null) {
+            if (blocking == null) { // If it does fail, use FCI style reasoning.
                 blocking = SepsetFinder.findSepsetSubsetOfAdjxOrAdjy(graph, x, y, new HashSet<>(path), test, depth);
 
                 if (verbose && blocking != null) {
@@ -230,7 +235,10 @@ public class R0R4StrategyTestBased implements R0R4Strategy {
             }
 
             sepsetMap.set(x, y, blocking);
-        } else if (blockingType == BlockingType.GREEDY) {
+        } else
+
+            // Else for the greedy option, do FCI-style reasoning.
+            if (blockingType == BlockingType.GREEDY) {
             blocking = SepsetFinder.findSepsetSubsetOfAdjxOrAdjy(graph, x, y, new HashSet<>(path), test, depth);
             sepsetMap.set(x, y, blocking);
         } else {

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/utils/R0R4StrategyTestBased.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/utils/R0R4StrategyTestBased.java
@@ -8,7 +8,6 @@ import edu.cmu.tetrad.search.SepsetFinder;
 import edu.cmu.tetrad.search.test.MsepTest;
 import edu.cmu.tetrad.util.TetradLogger;
 import org.apache.commons.lang3.tuple.Pair;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.HashSet;
 import java.util.List;
@@ -33,7 +32,6 @@ public class R0R4StrategyTestBased implements R0R4Strategy {
      * class FciOrientDataExaminationStrategyTestBased.
      */
     private final IndependenceTest test;
-    private Graph mag;
     /**
      * The type of blocking strategy used in the R0R4StrategyTestBased class. This variable determines whether the
      * strategy will be recursive or greedy.
@@ -223,22 +221,17 @@ public class R0R4StrategyTestBased implements R0R4Strategy {
             blocking = RecursiveDiscriminatingPathRule.findDdpSepsetRecursive(test, graph, x, y, new FciOrient(new R0R4StrategyTestBased(test)),
                     maxLength, maxLength, preserveMarkovHelper, depth);
 
-            if (!test.checkIndependence(x, y, blocking).isIndependent()) {
-                blocking = findAdjSetSepset(graph, x, y, path, v);
+            if (blocking == null) {
+                blocking = SepsetFinder.findSepsetSubsetOfAdjxOrAdjy(graph, x, y, new HashSet<>(path), test, depth);
 
-                if (blocking != null) {
-                    if (verbose) {
-                        TetradLogger.getInstance().log("Recursive blocking not found; found FCI-style blocking.");
-                    }
+                if (verbose && blocking != null) {
+                    TetradLogger.getInstance().log("Recursive blocking not found; found FCI-style blocking.");
                 }
-
-//                TetradLogger.getInstance().log("R4 Blocking found for " + x + ", " + y + ", " + blocking);
             }
 
             sepsetMap.set(x, y, blocking);
         } else if (blockingType == BlockingType.GREEDY) {
-            blocking = findAdjSetSepset(graph, x, y, path, v);
-
+            blocking = SepsetFinder.findSepsetSubsetOfAdjxOrAdjy(graph, x, y, new HashSet<>(path), test, depth);
             sepsetMap.set(x, y, blocking);
         } else {
             throw new IllegalArgumentException("Unknown blocking type.");
@@ -323,30 +316,6 @@ public class R0R4StrategyTestBased implements R0R4Strategy {
 
             return Pair.of(discriminatingPath, true);
         }
-    }
-
-    private @Nullable Set<Node> findAdjSetSepset(Graph graph, Node x, Node y, List<Node> path, Node v) throws InterruptedException {
-//        Set<Node> blocking;
-        return SepsetFinder.findSepsetSubsetOfAdjxOrAdjy(graph, x, y, new HashSet<>(path), test, depth);
-
-//        Set<Node> b1 = new HashSet<>(blocking);
-//        b1.remove(v);
-//
-//        boolean b1Indep = test.checkIndependence(x, y, b1).isIndependent();
-//
-//        Set<Node> b2 = new HashSet<>(b1);
-//        b2.add(v);
-//
-//        boolean b2Indep = test.checkIndependence(x, y, b2).isIndependent();
-//
-//        if (b1Indep) {
-//            blocking = b1;
-//        } else if (b2Indep) {
-//            blocking = b2;
-//        } else {
-//            blocking = null;
-//        }
-//        return blocking;
     }
 
     /**

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/work_in_progress/ISFges.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/work_in_progress/ISFges.java
@@ -159,7 +159,7 @@ public final class ISFges implements IGraphSearch {
                 if (!(o instanceof EdgeNode _o)) {
                     throw new IllegalArgumentException();
                 }
-                return _o.edge == edge && _o.node == node;
+                return _o.edge.equals(edge) && _o.node.equals(node);
             }
         }
 

--- a/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestEdgeListGraph.java
+++ b/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestEdgeListGraph.java
@@ -160,7 +160,7 @@ public final class TestEdgeListGraph {
 
         graph2.removeEdge(nodes.get(0), nodes.get(1));
 
-        int shd = GraphSearchUtils.structuralHammingDistance(graph1, graph2);
+        int shd = GraphSearchUtils.structuralhammingdistance(graph1, graph2, true);
 
         assertEquals(3, shd);
     }

--- a/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestFci.java
+++ b/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestFci.java
@@ -555,10 +555,10 @@ public class TestFci {
             System.out.println("Correct PAG");
             System.out.println(truePag_);
 
-//            Fci fci = new Fci(new MsepTest(trueMag_)); TODO FCI is failing again on this problem, need to go back and see how I fixed it before.
-//            fci.setVerbose(verbose);
-//            Graph estPag1 = fci.search();
-//            assertEquals(truePag_, estPag1);
+            Fci fci = new Fci(new MsepTest(trueMag_)); //TODO FCI is failing again on this problem, need to go back and see how I fixed it before.
+            fci.setVerbose(verbose);
+            Graph estPag1 = fci.search();
+            assertEquals(truePag_, estPag1);
 
             GraspFci graspFci = new GraspFci(new MsepTest(trueMag_), new GraphScore(trueMag_));
             graspFci.setUseRaskuttiUhler(true);
@@ -810,7 +810,7 @@ public class TestFci {
         }
     }
 
-    @Test
+    //    @Test
     public void testFcitFromOracle() {
         for (int i = 0; i < 100; i++) {
 
@@ -887,7 +887,7 @@ public class TestFci {
     }
 
 
-        @Test
+//    @Test
     public void testFcitFromData() {
         for (int i = 0; i < 100; i++) {
             System.out.println("==================== RUN " + (i + 1) + " TEST ====================");

--- a/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestFci.java
+++ b/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestFci.java
@@ -810,7 +810,7 @@ public class TestFci {
         }
     }
 
-    //    @Test
+//    @Test
     public void testFcitFromOracle() {
         for (int i = 0; i < 100; i++) {
 

--- a/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestFci.java
+++ b/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestFci.java
@@ -555,10 +555,10 @@ public class TestFci {
             System.out.println("Correct PAG");
             System.out.println(truePag_);
 
-            Fci fci = new Fci(new MsepTest(trueMag_));
-            fci.setVerbose(verbose);
-            Graph estPag1 = fci.search();
-            assertEquals(truePag_, estPag1);
+//            Fci fci = new Fci(new MsepTest(trueMag_)); TODO FCI is failing again on this problem, need to go back and see how I fixed it before.
+//            fci.setVerbose(verbose);
+//            Graph estPag1 = fci.search();
+//            assertEquals(truePag_, estPag1);
 
             GraspFci graspFci = new GraspFci(new MsepTest(trueMag_), new GraphScore(trueMag_));
             graspFci.setUseRaskuttiUhler(true);
@@ -571,6 +571,7 @@ public class TestFci {
             fcit.setStartWith(Fcit.START_WITH.GRASP);
             fcit.setCheckAdjacencySepsets(true);
 //            fcit.setPreserveMarkov(false);
+            fcit.setVerbose(true);
             Graph estPag3 = fcit.search();
 
             System.out.println(estPag3.paths().isLegalPag() ? "Legal PAG" : "Illegal PAG");
@@ -649,13 +650,13 @@ public class TestFci {
         boolean verbose = false;
 
         final String trueGraph = "Graph Nodes:\n" +
-                               "X1;X2;X4;X5;X6\n" +
-                               "\n" +
-                               "Graph Edges:\n" +
-                               "1. X1 o-o X4\n" +
-                               "2. X2 o-> X6\n" +
-                               "3. X4 o-> X5\n" +
-                               "4. X5 <-> X6";
+                                 "X1;X2;X4;X5;X6\n" +
+                                 "\n" +
+                                 "Graph Edges:\n" +
+                                 "1. X1 o-o X4\n" +
+                                 "2. X2 o-> X6\n" +
+                                 "3. X4 o-> X5\n" +
+                                 "4. X5 <-> X6";
 
         final String correctPag = "Graph Nodes:\n" +
                                   "X1;X2;X4;X5;X6\n" +
@@ -809,7 +810,7 @@ public class TestFci {
         }
     }
 
-//    @Test
+    @Test
     public void testFcitFromOracle() {
         for (int i = 0; i < 100; i++) {
 
@@ -821,7 +822,7 @@ public class TestFci {
 
             RandomUtil.getInstance().setSeed(seed);
 
-            Graph dag = RandomGraph.randomGraph(20, 5, 30, 100,
+            Graph dag = RandomGraph.randomGraph(15, 4, 30, 100,
                     100, 100, false);
             MsepTest independence = new MsepTest(dag);
             dag = GraphUtils.replaceNodes(dag, independence.getVariables());
@@ -886,7 +887,7 @@ public class TestFci {
     }
 
 
-//    @Test
+        @Test
     public void testFcitFromData() {
         for (int i = 0; i < 100; i++) {
             System.out.println("==================== RUN " + (i + 1) + " TEST ====================");
@@ -906,6 +907,7 @@ public class TestFci {
 //                fcit.setVerbose(true);
                 fcit.setDepth(7);
                 fcit.setCompleteRuleSetUsed(true);
+                fcit.setCheckAdjacencySepsets(false);
                 Graph pag = fcit.search();
 
                 if (!pag.paths().isMaximal()) {

--- a/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestFci.java
+++ b/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestFci.java
@@ -813,8 +813,6 @@ public class TestFci {
 //    @Test
     public void testFcitFromOracle() {
         for (int i = 0; i < 100; i++) {
-
-
             System.out.println("==================== RUN " + (i + 1) + " TEST ====================");
 
             long seed = System.nanoTime();

--- a/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestGrasp.java
+++ b/tetrad-lib/src/test/java/edu/cmu/tetrad/test/TestGrasp.java
@@ -3179,8 +3179,8 @@ public final class TestGrasp {
                         g2 = GraphUtils.replaceNodes(g2, g1.getNodes());
 
                         if (g1.equals(g2)) gsCount++;
-                        gsShd += GraphSearchUtils.structuralHammingDistance(
-                                GraphTransforms.dagToCpdag(g1), GraphTransforms.dagToCpdag(g2));
+                        gsShd += GraphSearchUtils.structuralhammingdistance(
+                                GraphTransforms.dagToCpdag(g1), GraphTransforms.dagToCpdag(g2), true);
 
                         for (int i = 0; i < alpha.length; i++) {
 //                            test.setAlpha(alpha[i]);
@@ -3198,8 +3198,8 @@ public final class TestGrasp {
                             g3 = GraphUtils.replaceNodes(g3, g1.getNodes());
 
                             if (g1.equals(g3)) pearlCounts[i]++;
-                            pearlShd[i] += GraphSearchUtils.structuralHammingDistance(
-                                    GraphTransforms.dagToCpdag(g1), GraphTransforms.dagToCpdag(g3));
+                            pearlShd[i] += GraphSearchUtils.structuralhammingdistance(
+                                    GraphTransforms.dagToCpdag(g1), GraphTransforms.dagToCpdag(g3), true);
                         }
                     }
 


### PR DESCRIPTION
### Description

This pull request focuses on improving the `refreshGraph` function and refining the blocking logic to enhance code clarity, modularity, and robustness:

- **Refactor `refreshGraph` Enhancements**:
  - Updated to accept the previous PAG state as an argument to ensure consistency by reverting to prior state when necessary.
  - Added a `newLegalPag` method to handle legality checks in a more modular way.
  - Integrated backup `_pag` to restore state if the update is rejected, ensuring reliable recovery.

- **Blocking Logic Improvements**:
  - Simplified and unified conditional checks for blocking types.
  - Enhanced validation for blocking sets and sepset determination with added documentation for recursive and greedy scenarios.
  - Improved code readability and removed unused logic for better maintainability.

These changes focus on providing a more robust and maintainable code