### PR TITLE
Make allIndependenceFacts a field in MarkovCheck

### DIFF
--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/MarkovCheck.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/MarkovCheck.java
@@ -166,6 +166,11 @@ public class MarkovCheck implements EffectiveSampleSizeSettable {
     private boolean verbose = false;
 
     /**
+     * The most recent list of all independence facts used by the generate results method.
+     */
+    private Set<IndependenceFact> allIndependenceFacts = null;
+
+    /**
      * Constructor. Takes a graph and an independence test over the variables of the graph.
      *
      * @param graph            The graph.
@@ -932,6 +937,7 @@ public class MarkovCheck implements EffectiveSampleSizeSettable {
                     }
                 }
             }
+            this.allIndependenceFacts = allIndependenceFacts;
 
             try {
                 generateMseps(new ArrayList<>(allIndependenceFacts), msep, mconn, new MsepTest(graph));


### PR DESCRIPTION
This PR introduces `allIndependenceFacts` as a new field in the `MarkovCheck` class.

Previously, `allIndependenceFacts` was a local variable within the `generateResults `method. By promoting it to a class-level field, we enable its reuse in downstream methods. In particular, this change supports optimization efforts in the Nodewise MarkovCheck workflow.