### PR TITLE
getPrecisionAndRecallGraphPlotData with subgraph features

### DIFF
--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/graph/GraphUtils.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/graph/GraphUtils.java
@@ -147,6 +147,38 @@ public final class GraphUtils {
     }
 
     /**
+     * Calculates the subgraph over the parents of a target node for a DAG, CPDAG, MAG, or PAG. This is not
+     * necessarily minimal (i.e. not necessarily a Markov Boundary). Target Node is included in the result graph's nodes
+     * list. Edges including the target node is included in the result graph's edges list.
+     *
+     * @param target a node in the given graph.
+     * @param graph  a DAG, CPDAG, MAG, or PAG.
+     * @return a {@link edu.cmu.tetrad.graph.Graph} object
+     */
+    public static Graph getParentsSubgraphWithTargetNode(Graph graph, Node target) {
+        EdgeListGraph g = new EdgeListGraph(graph);
+        List<Node> parents = graph.getParents(target);
+        parents.add(target);
+        return g.subgraph(parents);
+    }
+
+    /**
+     * Calculates the subgraph over the adjacency of a target node for a DAG, CPDAG, MAG, or PAG. This is not
+     * necessarily minimal (i.e. not necessarily a Markov Boundary). Target Node is included in the result graph's nodes
+     * list. Edges including the target node is included in the result graph's edges list.
+     *
+     * @param target a node in the given graph.
+     * @param graph  a DAG, CPDAG, MAG, or PAG.
+     * @return a {@link edu.cmu.tetrad.graph.Graph} object
+     */
+    public static Graph getAdjacencySubgraphWithTargetNode(Graph graph, Node target) {
+        EdgeListGraph g = new EdgeListGraph(graph);
+        List<Node> adjs = graph.getAdjacentNodes(target);
+        adjs.add(target);
+        return g.subgraph(adjs);
+    }
+
+    /**
      * <p>removeBidirectedOrientations.</p>
      *
      * @param estCpdag a {@link edu.cmu.tetrad.graph.Graph} object

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/MarkovCheck.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/MarkovCheck.java
@@ -721,6 +721,49 @@ public class MarkovCheck implements EffectiveSampleSizeSettable {
     }
 
     /**
+     *
+     * Calculates the precision and recall on the general definition of local sub graph of a target node, plot data.
+     * @param x
+     * @param estimatedGraph
+     * @param trueGraph
+     * @param conditioningSetType
+     * @param subgraphFeature features of a subgraph, can be either parents, adjacencies, or MB.
+     * @return
+     */
+    public List<Double> getPrecisionAndRecallGraphPlotData(Node x, Graph estimatedGraph, Graph trueGraph, ConditioningSetType conditioningSetType, String subgraphFeature) {
+        // Lookup graph is the same structure as trueGraph's structure but node objects replaced by estimated graph nodes.
+        Graph lookupGraph = GraphUtils.replaceNodes(trueGraph, estimatedGraph.getNodes());
+        Graph xConditioningSetTypeLookupGraph = null;
+        Graph xConditioningSetTypeEstimatedGraph = null;
+
+        // A more general definition of what "local subgraph" means
+        if (subgraphFeature.equals("MB")) { // TODO VBC: create a enum for subgraph features
+            xConditioningSetTypeLookupGraph = GraphUtils.getMarkovBlanketSubgraphWithTargetNode(lookupGraph, x);
+            System.out.println("xMBLookupGraph:" + xConditioningSetTypeLookupGraph);
+            xConditioningSetTypeEstimatedGraph = GraphUtils.getMarkovBlanketSubgraphWithTargetNode(estimatedGraph, x);
+            System.out.println("xMBEstimatedGraph:" + xConditioningSetTypeEstimatedGraph);
+        } else if (subgraphFeature.equals("parents")) {
+            xConditioningSetTypeLookupGraph = GraphUtils.getParentsSubgraphWithTargetNode(lookupGraph, x);
+            System.out.println("xParentsLookupGraph:" + xConditioningSetTypeLookupGraph);
+            xConditioningSetTypeEstimatedGraph = GraphUtils.getParentsSubgraphWithTargetNode(estimatedGraph, x);
+            System.out.println("xParentsEstimatedGraph:" + xConditioningSetTypeEstimatedGraph);
+        } else if (subgraphFeature.equals("adjacency")) {
+            xConditioningSetTypeLookupGraph = GraphUtils.getAdjacencySubgraphWithTargetNode(lookupGraph, x);
+            System.out.println("xParentsLookupGraph:" + xConditioningSetTypeLookupGraph);
+            xConditioningSetTypeEstimatedGraph = GraphUtils.getAdjacencySubgraphWithTargetNode(estimatedGraph, x);
+            System.out.println("xParentsEstimatedGraph:" + xConditioningSetTypeEstimatedGraph);
+
+        } else {
+            throw new IllegalArgumentException("Unsupported subgraph feature: " + subgraphFeature);
+        }
+        double ap = new AdjacencyPrecision().getValue(xConditioningSetTypeLookupGraph, xConditioningSetTypeEstimatedGraph, null, new Parameters());
+        double ar = new AdjacencyRecall().getValue(xConditioningSetTypeLookupGraph, xConditioningSetTypeEstimatedGraph, null, new Parameters());
+        double ahp = new ArrowheadPrecision().getValue(xConditioningSetTypeLookupGraph, xConditioningSetTypeEstimatedGraph, null, new Parameters());
+        double ahr = new ArrowheadRecall().getValue(xConditioningSetTypeLookupGraph, xConditioningSetTypeEstimatedGraph, null, new Parameters());
+        return Arrays.asList(ap, ar, ahp, ahr);
+    }
+
+    /**
      * Calculates the precision and recall using LocalGraphConfusion (which calculates the combination of Adjacency and
      * ArrowHead) on the Markov Blanket graph for a given node. Prints the statistics to the console.
      *


### PR DESCRIPTION
In Markov Chcker `getPrecisionAndRecallGraphPlotData` method now can depends on selected subgraph feature. 
Added methods to find local subgraph for parents, for adjacencies besides existing MB subgraph. 