### PR TITLE
checkIndependenceForTargetNode care about odering for OLMM case

### DIFF
--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/search/MarkovCheck.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/search/MarkovCheck.java
@@ -251,7 +251,11 @@ public class MarkovCheck implements EffectiveSampleSizeSettable {
         }
 
         for (IndependenceFact fact : allIndependenceFacts) {
-            if (x.equals((fact.getX())) || x.equals(fact.getY())) facts.add(fact);
+            if (this.setType == ConditioningSetType.ORDERED_LOCAL_MARKOV) {
+                if (x.equals((fact.getX()))) facts.add(fact);
+            } else {
+                if (x.equals((fact.getX())) || x.equals(fact.getY())) facts.add(fact);
+            }
         }
         return facts;
     }


### PR DESCRIPTION
`checkIndependenceForTargetNode` when getting back a list of `IndependenceFact` for target node, needs to consider sequence of x, y position when the Markov Checker is of `ORDERED_LOCAL_MARKOV` condition set type. 