### PR TITLE
F1 statistics for circles

### DIFF
--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/statistic/F1Circle.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/statistic/F1Circle.java
@@ -1,6 +1,6 @@
 package edu.cmu.tetrad.algcomparison.statistic;
 
-import edu.cmu.tetrad.algcomparison.statistic.utils.ArrowConfusion;
+import edu.cmu.tetrad.algcomparison.statistic.utils.CircleConfusion;
 import edu.cmu.tetrad.data.DataModel;
 import edu.cmu.tetrad.graph.Graph;
 import edu.cmu.tetrad.util.Parameters;
@@ -33,7 +33,7 @@ public class F1Circle implements Statistic{
      */
     @Override
     public String getAbbreviation() {
-        return "F1Arrow";
+        return "F1Circle";
     }
 
     /**
@@ -41,7 +41,7 @@ public class F1Circle implements Statistic{
      */
     @Override
     public String getDescription() {
-        return "F1 statistic for arrows";
+        return "F1 statistic for circles";
     }
 
     /**
@@ -49,13 +49,13 @@ public class F1Circle implements Statistic{
      */
     @Override
     public double getValue(Graph trueGraph, Graph estGraph, DataModel dataModel, Parameters parameters) {
-        ArrowConfusion arrowConfusion = new ArrowConfusion(trueGraph, estGraph);
-        int arrowTp = arrowConfusion.getTp();
-        int arrowFp = arrowConfusion.getFp();
-        int arrowFn = arrowConfusion.getFn();
-        double arrowPrecision = arrowTp / (double) (arrowTp + arrowFp);
-        double arrowRecall = arrowTp / (double) (arrowTp + arrowFn);
-        return 2 * (arrowPrecision * arrowRecall) / (arrowPrecision + arrowRecall);
+        CircleConfusion circleConfusion = new CircleConfusion(trueGraph, estGraph);
+        int circleTp = circleConfusion.getTp();
+        int circleFp = circleConfusion.getFp();
+        int circleFn = circleConfusion.getFn();
+        double circlePrecision = circleTp / (double) (circleTp + circleFp);
+        double circleRecall = circleTp / (double) (circleTp + circleFn);
+        return 2 * (circlePrecision * circleRecall) / (circlePrecision + circleRecall);
     }
 
     /**

--- a/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/statistic/F1Circle.java
+++ b/tetrad-lib/src/main/java/edu/cmu/tetrad/algcomparison/statistic/F1Circle.java
@@ -1,0 +1,68 @@
+package edu.cmu.tetrad.algcomparison.statistic;
+
+import edu.cmu.tetrad.algcomparison.statistic.utils.ArrowConfusion;
+import edu.cmu.tetrad.data.DataModel;
+import edu.cmu.tetrad.graph.Graph;
+import edu.cmu.tetrad.util.Parameters;
+
+import java.io.Serial;
+
+/**
+ * Calculates the F1 statistic for circles.
+ * <p>
+ *  <a href="https://en.wikipedia.org/wiki/F1_score">...</a>
+ *  <p>
+ *  We use what's on this page called the "traditional" F1 statistic.
+ *  If the true contains X*-oY and estimated graph
+ *  either does not contain an edge from X to Y or else does not contain a tail at X for an edge from X to Y, one
+ *  false positive is counted. Similarly for false negatives
+ *  *
+ */
+public class F1Circle implements Statistic{
+    @Serial
+    private static final long serialVersionUID = 23L;
+
+    /**
+     * Constructs a new instance of the algorithm.
+     */
+    public F1Circle() {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getAbbreviation() {
+        return "F1Arrow";
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getDescription() {
+        return "F1 statistic for arrows";
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public double getValue(Graph trueGraph, Graph estGraph, DataModel dataModel, Parameters parameters) {
+        ArrowConfusion arrowConfusion = new ArrowConfusion(trueGraph, estGraph);
+        int arrowTp = arrowConfusion.getTp();
+        int arrowFp = arrowConfusion.getFp();
+        int arrowFn = arrowConfusion.getFn();
+        double arrowPrecision = arrowTp / (double) (arrowTp + arrowFp);
+        double arrowRecall = arrowTp / (double) (arrowTp + arrowFn);
+        return 2 * (arrowPrecision * arrowRecall) / (arrowPrecision + arrowRecall);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public double getNormValue(double value) {
+        return value;
+    }
+}


### PR DESCRIPTION
Calculate F1 statistics for circles by using the precision and recall calculated based on `CircleConfusion`'s `Tp`, `Fp`, `Fn`